### PR TITLE
Bump/v1.2.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,8 +87,14 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          cd build/bin
-          tar -czf ${{ env.APP_NAME }}-${VERSION}-linux-${{ matrix.arch }}.tar.gz ${{ env.APP_NAME }}
+          STAGING="${{ env.APP_NAME }}-${VERSION}-linux-${{ matrix.arch }}"
+          mkdir -p "$STAGING"
+          cp build/bin/${{ env.APP_NAME }} "$STAGING/"
+          cp fingergo.png "$STAGING/"
+          cp io.github.AshBuk.FingerGo.desktop "$STAGING/"
+          cp scripts/install.sh scripts/uninstall.sh scripts/INSTALL.txt "$STAGING/"
+          chmod +x "$STAGING/install.sh" "$STAGING/uninstall.sh"
+          tar -czf "build/bin/${STAGING}.tar.gz" "$STAGING"
 
       # ==================== macOS Packaging ====================
       - name: Package macOS artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to FingerGo will be documented in this file.
 
+## [1.2.3] - 2026-03-19
+
+### Enhanced
+- Published on [Flathub](https://flathub.org/apps/io.github.AshBuk.FingerGo)
+- Refined Linux tar release: include install/uninstall scripts, icon, and .desktop entry for desktop integration (app menu, launcher)
+
 ## [1.2.2] - 2026-03-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
   <a href="https://github.com/AshBuk/FingerGo/releases"><img src="https://img.shields.io/badge/Windows-available-blue?logo=windows" alt="Windows"></a>
   <a href="https://github.com/AshBuk/FingerGo/releases"><img src="https://img.shields.io/badge/macOS-available-blue?logo=apple" alt="macOS"></a>
   <a href="https://github.com/AshBuk/FingerGo/releases"><img src="https://img.shields.io/badge/Linux-available-blue?logo=linux&logoColor=white" alt="Linux"></a>
+  <a href="https://flathub.org/apps/io.github.AshBuk.FingerGo"><img src="https://img.shields.io/flathub/v/io.github.AshBuk.FingerGo" alt="Flathub"></a>
   <a href="https://github.com/AshBuk/FingerGo/releases"><img src="https://img.shields.io/github/v/release/AshBuk/FingerGo?sort=semver" alt="Release"></a>
 </p>
 
@@ -54,19 +55,24 @@ Built with Go ↔ Wails ↔ Vanilla JavaScript (ES6+). Available for **Linux, ma
 
 **Supports:** Intel and Apple Silicon (Universal binary)
 
-### 🐧 Linux [Releases](https://github.com/AshBuk/FingerGo/releases/latest)
+### 🐧 Linux
 
-**Flatpak:**
+**Flatpak (recommended):**
+
+<a href="https://flathub.org/apps/io.github.AshBuk.FingerGo">
+  <img src="https://flathub.org/api/badge?locale=en" width="190" alt="Get it on Flathub">
+</a>
+
 ```bash
-flatpak install --user FingerGo-{VERSION}-x86_64.flatpak
-flatpak run com.ashbuk.FingerGo
+flatpak install flathub io.github.AshBuk.FingerGo
+flatpak run io.github.AshBuk.FingerGo
 ```
 
-**Portable (tar.gz):**
+**Portable (tar.gz):** [Release](https://github.com/AshBuk/FingerGo/releases/latest)
 ```bash
 # Requires WebKit2GTK 4.1 installed on your system.
 tar -xzf FingerGo-{VERSION}-linux-x86_64.tar.gz
-./FingerGo
+./FingerGo    # or run install.sh for desktop integration
 ```
 
 ---

--- a/flatpak/io.github.AshBuk.FingerGo.yml
+++ b/flatpak/io.github.AshBuk.FingerGo.yml
@@ -11,7 +11,6 @@ finish-args:
   - --share=ipc
   - --socket=fallback-x11
   - --socket=wayland
-  - --socket=pulseaudio
   - --device=dri
 
 modules:
@@ -27,7 +26,6 @@ modules:
         GOTOOLCHAIN: local
         CGO_ENABLED: '1'
     build-commands:
-      - . /usr/lib/sdk/golang/enable.sh
       - |
         go build \
           -tags desktop,production,webkit2_41 \

--- a/io.github.AshBuk.FingerGo.desktop
+++ b/io.github.AshBuk.FingerGo.desktop
@@ -7,6 +7,7 @@ Categories=Education;Utility;
 Exec=fingergo
 Icon=io.github.AshBuk.FingerGo
 Terminal=false
+StartupWMClass=fingergo
 StartupNotify=true
 Keywords=typing;keyboard;training;education;wpm;
 

--- a/io.github.AshBuk.FingerGo.metainfo.xml
+++ b/io.github.AshBuk.FingerGo.metainfo.xml
@@ -3,7 +3,7 @@
   <id>io.github.AshBuk.FingerGo</id>
 
   <name>FingerGo</name>
-  <summary>Touch typing trainer with visual keyboard feedback</summary>
+  <summary>Visual touch-typing trainer</summary>
 
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>Apache-2.0</project_license>
@@ -36,7 +36,7 @@
 
   <screenshots>
     <screenshot type="default">
-      <image>https://raw.githubusercontent.com/AshBuk/FingerGo/v1.2.2/screen/fingergo-screen.png</image>
+      <image>https://raw.githubusercontent.com/AshBuk/FingerGo/v1.2.3/screen/fingergo-screen.png</image>
       <caption>Main typing interface with visual keyboard and real-time statistics</caption>
     </screenshot>
   </screenshots>
@@ -67,29 +67,14 @@
   </keywords>
   
   <releases>
-    <release version="1.2.2" date="2026-03-10">
+    <release version="1.2.3" date="2026-03-19">
       <description>
-        <p>Flathub submission fixes</p>
+        <p>Flathub listing</p>
       </description>
     </release>
-    <release version="1.2.1" date="2026-03-09">
-      <description>
-        <p>Flatpak offline build and dependency update</p>
-      </description>
-    </release>
-    <release version="1.2.0" date="2026-02-08">
-      <description>
-        <p>Multiple keyboard layout support</p>
-        <ul>
-          <li>Dynamic keyboard layout switching with layout selector</li>
-          <li>English Dvorak keyboard layout</li>
-          <li>Russian JCUKEN layout with Cyrillic input support</li>
-          <li>German QWERTZ keyboard layout</li>
-          <li>Layout preference persistence across sessions</li>
-          <li>Backspace clears error state in typing display</li>
-        </ul>
-      </description>
-    </release>
+    <release version="1.2.2" date="2026-03-10"/>
+    <release version="1.2.1" date="2026-03-09"/>
+    <release version="1.2.0" date="2026-02-08"/>
     <release version="1.1.2" date="2026-01-26"/>
     <release version="1.1.1" date="2025-12-30"/>
     <release version="1.1.0" date="2025-12-27"/>

--- a/scripts/INSTALL.txt
+++ b/scripts/INSTALL.txt
@@ -1,0 +1,18 @@
+FingerGo — Touch Typing Trainer
+https://github.com/AshBuk/FingerGo
+
+Run the binary directly
+-----------
+  ./FingerGo            
+
+Install (Linux)
+---------------
+  ./install.sh          Install binary, icon, and .desktop entry to ~/.local
+  fingergo              Launch from terminal or app menu
+
+  Note: install.sh places the binary in ~/.local/bin.
+        Make sure this directory is in your PATH.
+
+Uninstall
+---------
+  ./uninstall.sh        Remove all installed files

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Copyright 2025-2026 Asher Buk
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/AshBuk/FingerGo
+#
+# Install FingerGo to user-local directories (~/.local)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+BIN_DIR="$HOME/.local/bin"
+ICON_DIR="$HOME/.local/share/icons/hicolor/512x512/apps"
+APP_DIR="$HOME/.local/share/applications"
+
+mkdir -p "$BIN_DIR" "$ICON_DIR" "$APP_DIR"
+
+install -m755 "$SCRIPT_DIR/FingerGo" "$BIN_DIR/fingergo"
+install -m644 "$SCRIPT_DIR/fingergo.png" "$ICON_DIR/io.github.AshBuk.FingerGo.png"
+install -m644 "$SCRIPT_DIR/io.github.AshBuk.FingerGo.desktop" "$APP_DIR/io.github.AshBuk.FingerGo.desktop"
+
+gtk-update-icon-cache -f -t "$HOME/.local/share/icons/hicolor" 2>/dev/null || true
+update-desktop-database "$APP_DIR" 2>/dev/null || true
+
+echo "FingerGo installed successfully."
+echo "Make sure $BIN_DIR is in your PATH."

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Copyright 2025-2026 Asher Buk
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/AshBuk/FingerGo
+#
+# Uninstall FingerGo from user-local directories (~/.local)
+
+set -euo pipefail
+
+rm -f "$HOME/.local/bin/fingergo"
+rm -f "$HOME/.local/share/icons/hicolor/512x512/apps/io.github.AshBuk.FingerGo.png"
+rm -f "$HOME/.local/share/applications/io.github.AshBuk.FingerGo.desktop"
+
+gtk-update-icon-cache -f -t "$HOME/.local/share/icons/hicolor" 2>/dev/null || true
+update-desktop-database "$HOME/.local/share/applications" 2>/dev/null || true
+
+echo "FingerGo uninstalled successfully."


### PR DESCRIPTION
Bump version to 1.2.3 with Flathub listing improvements. 
Shortens metainfo summary to meet Flathub quality guidelines, removes unused pulseaudio permission.

Enhances Linux tar release with install/uninstall scripts and desktop integration files.



