### PR TITLE
Window/zoom and tab size

### DIFF
--- a/gui/src/index.html
+++ b/gui/src/index.html
@@ -125,6 +125,24 @@ https://github.com/AshBuk/FingerGo
 
             <!-- Library Controls (right edge) -->
             <div id="library-controls" role="region" aria-label="Library controls">
+                <div id="zoom-controls">
+                    <button
+                        id="zoom-out"
+                        aria-label="Decrease text size"
+                        title="Decrease text size (Ctrl+−)"
+                        type="button"
+                    >
+                        −
+                    </button>
+                    <button
+                        id="zoom-in"
+                        aria-label="Increase text size"
+                        title="Increase text size (Ctrl++)"
+                        type="button"
+                    >
+                        +
+                    </button>
+                </div>
                 <button
                     id="library-toggle"
                     aria-label="Library"

--- a/gui/src/js/app.js
+++ b/gui/src/js/app.js
@@ -28,6 +28,8 @@
         bind('keyboard-toggle', () => window.SettingsManager.toggleKeyboard());
         bind('reset-session', () => window.SessionManager.reset());
         bind('strict-mode-toggle', () => window.SettingsManager.toggleStrictMode());
+        bind('zoom-in', () => window.SettingsManager.zoomIn());
+        bind('zoom-out', () => window.SettingsManager.zoomOut());
         bind('layout-toggle', () => window.UIManager?.showModal('settings', {}));
         // GitHub link
         const githubLink = document.getElementById('github-link');
@@ -89,6 +91,9 @@
         window.SettingsManager.applyStrictMode(settings.strictMode, false);
         if (settings.keyboardLayout) {
             window.SettingsManager.applyKeyboardLayout(settings.keyboardLayout, false);
+        }
+        if (settings.textZoom && settings.textZoom !== 1.0) {
+            window.SettingsManager.applyTextZoom(settings.textZoom, false);
         }
         // Bind UI handlers
         bindButtonHandlers();

--- a/gui/src/js/settings.js
+++ b/gui/src/js/settings.js
@@ -14,6 +14,11 @@
     let isStatsBarVisible = true;
     let isStrictMode = false;
     let currentKeyboardLayout = 'en-qwerty';
+    let textZoom = 1.0;
+
+    const ZOOM_MIN = 0.5;
+    const ZOOM_MAX = 2.0;
+    const ZOOM_STEP = 0.1;
 
     // DOM element references (cached on first use)
     const getEl = id => document.getElementById(id);
@@ -192,8 +197,34 @@
     }
 
     /**
+     * Apply text zoom level and optionally persist
+     * @param {number} level - Zoom multiplier (0.5–2.0)
+     * @param {boolean} [persist=true]
+     */
+    function applyTextZoom(level, persist = true) {
+        textZoom = Math.round(Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, level)) * 10) / 10;
+        const display = getEl('text-display');
+        const input = getEl('text-input');
+        if (display) display.style.setProperty('--text-zoom', textZoom);
+        if (input) input.style.setProperty('--text-zoom', textZoom);
+        if (persist) persistSetting('textZoom', textZoom);
+    }
+
+    function zoomIn() {
+        applyTextZoom(textZoom + ZOOM_STEP);
+    }
+
+    function zoomOut() {
+        applyTextZoom(textZoom - ZOOM_STEP);
+    }
+
+    function resetZoom() {
+        applyTextZoom(1.0);
+    }
+
+    /**
      * Load settings from internal layer
-     * @returns {Promise<{theme: string, zenMode: boolean, showKeyboard: boolean, showStatsBar: boolean, strictMode: boolean, keyboardLayout: string}>}
+     * @returns {Promise<{theme: string, zenMode: boolean, showKeyboard: boolean, showStatsBar: boolean, strictMode: boolean, keyboardLayout: string, textZoom: number}>}
      */
     async function load() {
         const defaults = {
@@ -203,6 +234,7 @@
             showStatsBar: true,
             strictMode: true,
             keyboardLayout: 'en-qwerty',
+            textZoom: 1.0,
         };
         if (!window.go?.app?.App?.GetSettings) return defaults;
         try {
@@ -227,11 +259,16 @@
         applyStrictMode,
         toggleStrictMode,
         applyKeyboardLayout,
+        applyTextZoom,
+        zoomIn,
+        zoomOut,
+        resetZoom,
         getTheme: () => currentTheme,
         isZenMode: () => isZenMode,
         isKeyboardVisible: () => isKeyboardVisible,
         isStatsBarVisible: () => isStatsBarVisible,
         isStrictMode: () => isStrictMode,
         getKeyboardLayout: () => currentKeyboardLayout,
+        getTextZoom: () => textZoom,
     };
 })();

--- a/gui/src/js/shortcuts.js
+++ b/gui/src/js/shortcuts.js
@@ -79,6 +79,24 @@
                 window.LibraryManager?.toggle();
                 return;
             }
+            // Ctrl+= / Ctrl++ - Zoom in text
+            if ((e.key === '=' || e.key === '+') && (e.ctrlKey || e.metaKey) && !e.altKey) {
+                e.preventDefault();
+                window.SettingsManager?.zoomIn();
+                return;
+            }
+            // Ctrl+- - Zoom out text
+            if (e.key === '-' && (e.ctrlKey || e.metaKey) && !e.altKey) {
+                e.preventDefault();
+                window.SettingsManager?.zoomOut();
+                return;
+            }
+            // Ctrl+0 - Reset zoom
+            if (e.key === '0' && (e.ctrlKey || e.metaKey) && !e.altKey) {
+                e.preventDefault();
+                window.SettingsManager?.resetZoom();
+                return;
+            }
             // Ctrl+Alt+N - Toggle text editor (new text or close if modal open)
             if (e.key === 'n' && (e.ctrlKey || e.metaKey) && e.altKey) {
                 e.preventDefault();

--- a/gui/src/styles/library.css
+++ b/gui/src/styles/library.css
@@ -43,6 +43,16 @@
     outline: 2px solid var(--accent);
     outline-offset: 2px;
 }
+#zoom-controls {
+    display: flex;
+    gap: 0.25rem;
+}
+#zoom-controls button {
+    flex: 1;
+    padding: 3px 0;
+    font-size: 0.65rem;
+    font-weight: 600;
+}
 
 /* Zen mode: hide library controls and sidebar */
 body.zen-mode #library-controls,

--- a/gui/src/styles/main.css
+++ b/gui/src/styles/main.css
@@ -115,9 +115,10 @@ body.zen-mode .top-action-button:not(#zen-toggle) {
     color: transparent;
     caret-color: transparent;
     font: inherit;
-    font-size: clamp(0.96rem, calc(0.98rem + 0.5vw), 1.28rem);
+    font-size: calc(clamp(0.96rem, 0.98rem + 0.5vw, 1.28rem) * var(--text-zoom, 1));
     line-height: 1.68;
     letter-spacing: 0.02em;
+    tab-size: 4;
     white-space: pre-wrap;
     overflow-wrap: break-word;
     word-break: break-word;
@@ -128,7 +129,7 @@ body.zen-mode .top-action-button:not(#zen-toggle) {
     flex: 1 1 auto;
     height: 100%;
     overflow-y: auto;
-    font-size: clamp(0.96rem, calc(0.98rem + 0.5vw), 1.28rem);
+    font-size: calc(clamp(0.96rem, 0.98rem + 0.5vw, 1.28rem) * var(--text-zoom, 1));
     line-height: 1.68;
     letter-spacing: 0.02em;
     color: var(--accent);
@@ -140,6 +141,7 @@ body.zen-mode .top-action-button:not(#zen-toggle) {
     background: rgba(var(--accent-rgb), 0.03);
     border-radius: 8px;
     min-height: 200px;
+    tab-size: 4;
     white-space: pre-wrap;
     word-wrap: break-word;
 }
@@ -273,7 +275,7 @@ body.zen-mode #text-area {
 /* Responsive adjustments */
 @media (max-width: 1400px) {
     #text-display {
-        font-size: 1.25rem;
+        font-size: calc(1.25rem * var(--text-zoom, 1));
         padding: 1.25rem 1.5rem;
     }
 
@@ -288,7 +290,7 @@ body.zen-mode #text-area {
 
 @media (max-width: 1024px) {
     #text-display {
-        font-size: clamp(0.95rem, 1.2vw + 0.4rem, 1.1rem);
+        font-size: calc(clamp(0.95rem, 1.2vw + 0.4rem, 1.1rem) * var(--text-zoom, 1));
         padding: 1rem;
     }
 

--- a/internal/domain/settings.go
+++ b/internal/domain/settings.go
@@ -6,13 +6,14 @@ package domain
 
 // Settings holds user preferences persisted in settings.json.
 type Settings struct {
-	Theme          string `json:"theme"`          // "dark" | "light"
-	LastTextID     string `json:"lastTextId"`     // last opened text ID for session restore
-	KeyboardLayout string `json:"keyboardLayout"` // keyboard layout ID (e.g., "en-qwerty", "en-dvorak")
-	ShowKeyboard   bool   `json:"showKeyboard"`   // keyboard section visibility
-	ShowStatsBar   bool   `json:"showStatsBar"`   // stats bar visibility
-	ZenMode        bool   `json:"zenMode"`        // focus mode (hides both keyboard and stats)
-	StrictMode     bool   `json:"strictMode"`     // require backspace to fix errors (true) or allow direct correction (false)
+	Theme          string  `json:"theme"`          // "dark" | "light"
+	LastTextID     string  `json:"lastTextId"`     // last opened text ID for session restore
+	KeyboardLayout string  `json:"keyboardLayout"` // keyboard layout ID (e.g., "en-qwerty", "en-dvorak")
+	ShowKeyboard   bool    `json:"showKeyboard"`   // keyboard section visibility
+	ShowStatsBar   bool    `json:"showStatsBar"`   // stats bar visibility
+	ZenMode        bool    `json:"zenMode"`        // focus mode (hides both keyboard and stats)
+	StrictMode     bool    `json:"strictMode"`     // require backspace to fix errors (true) or allow direct correction (false)
+	TextZoom       float64 `json:"textZoom"`       // text display zoom multiplier (0.5–2.0, default 1.0)
 }
 
 // DefaultSettings returns factory defaults for new installations.
@@ -24,5 +25,6 @@ func DefaultSettings() Settings {
 		ZenMode:        false,
 		StrictMode:     true,        // require backspace to fix errors (false = cheat mode)
 		KeyboardLayout: "en-qwerty", // default keyboard layout
+		TextZoom:       1.0,         // 100% text size
 	}
 }

--- a/internal/storage/settings.go
+++ b/internal/storage/settings.go
@@ -54,7 +54,7 @@ func (r *SettingsRepository) Save(s domain.Settings) error {
 }
 
 // Update modifies a single setting by key and persists the change.
-// Supported keys: "theme", "showKeyboard", "showStatsBar", "zenMode", "strictMode", "lastTextId", "keyboardLayout".
+// Supported keys: "theme", "showKeyboard", "showStatsBar", "zenMode", "strictMode", "lastTextId", "keyboardLayout", "textZoom".
 //
 //nolint:gocyclo // switch-based dispatch, linear and readable
 func (r *SettingsRepository) Update(key string, value any) error {
@@ -108,6 +108,15 @@ func (r *SettingsRepository) Update(key string, value any) error {
 			return fmt.Errorf("settings: keyboardLayout expects string, got %T", value)
 		}
 		updated.KeyboardLayout = v
+	case "textZoom":
+		v, ok := value.(float64)
+		if !ok {
+			return fmt.Errorf("settings: textZoom expects float64, got %T", value)
+		}
+		if v < 0.5 || v > 2.0 {
+			return fmt.Errorf("settings: textZoom out of range [0.5, 2.0]: %v", v)
+		}
+		updated.TextZoom = v
 	default:
 		return fmt.Errorf("settings: unknown key %q", key)
 	}
@@ -141,6 +150,9 @@ func (r *SettingsRepository) ensureLoaded() error {
 		var s domain.Settings
 		if err := json.Unmarshal(clean, &s); err != nil {
 			return fmt.Errorf("storage: parse config %q: %w", path, err)
+		}
+		if s.TextZoom == 0 {
+			s.TextZoom = 1.0
 		}
 		r.settings = s
 	}


### PR DESCRIPTION
Halve the default tab indentation width (8 → 4) in the text display area for better code readability. 
Add user-adjustable text zoom (50%–200%) with compact -/+ buttons and standard keyboard shortcuts (Ctrl++/−/0)