### PR TITLE
Add targeted practice and custom text practice modes

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -14,10 +14,11 @@ import (
 )
 
 type App struct {
-	storage      *storage.Manager            // Manages the application's data storage on disk
-	textsRepo    *storage.TextRepository     // Handles operations related to typing texts
-	sessionsRepo *storage.SessionRepository  // Manages the persistence of typing session data
-	settingsRepo *storage.SettingsRepository // Handles user preferences persistence
+	storage       *storage.Manager                 // Manages the application's data storage on disk
+	textsRepo     *storage.TextRepository          // Handles operations related to typing texts
+	sessionsRepo  *storage.SessionRepository       // Manages the persistence of typing session data
+	settingsRepo  *storage.SettingsRepository      // Handles user preferences persistence
+	practiceRepo  *storage.PracticeGroupRepository // Custom targeted-practice groups
 }
 
 func New() *App { return &App{} }
@@ -45,6 +46,9 @@ func (a *App) Startup(ctx context.Context) error {
 	// Settings repository is not critical — app can run with defaults
 	if err := a.ensureSettingsRepository(); err != nil {
 		log.Printf("WARNING: settings repository init failed, using defaults: %v", err)
+	}
+	if err := a.ensurePracticeRepository(); err != nil {
+		log.Printf("WARNING: practice group repository init failed: %v", err)
 	}
 	return nil
 }
@@ -153,6 +157,38 @@ func (a *App) SupportedLanguages() []domain.LanguageInfo {
 	return domain.SupportedLanguages()
 }
 
+// GetPracticeGroups returns persisted custom practice groups.
+func (a *App) GetPracticeGroups() ([]domain.PracticeGroup, error) {
+	if a.practiceRepo == nil {
+		return nil, fmt.Errorf("practice group repository not initialized")
+	}
+	return a.practiceRepo.List()
+}
+
+// SavePracticeGroup creates or updates a custom practice group.
+func (a *App) SavePracticeGroup(group *domain.PracticeGroup) (domain.PracticeGroup, error) {
+	if a.practiceRepo == nil {
+		return domain.PracticeGroup{}, fmt.Errorf("practice group repository not initialized")
+	}
+	return a.practiceRepo.Save(group)
+}
+
+// DeletePracticeGroup removes a custom practice group by ID.
+func (a *App) DeletePracticeGroup(id string) error {
+	if a.practiceRepo == nil {
+		return fmt.Errorf("practice group repository not initialized")
+	}
+	return a.practiceRepo.Delete(id)
+}
+
+// AggregateKeyMistakes returns summed mistake counts from recent sessions.
+func (a *App) AggregateKeyMistakes(limit int) (map[string]int, error) {
+	if a.sessionsRepo == nil {
+		return nil, fmt.Errorf("session repository not initialized")
+	}
+	return a.sessionsRepo.AggregateKeyMistakes(limit)
+}
+
 // ensureTextRepository initializes text repository if not already initialized.
 func (a *App) ensureTextRepository() error {
 	if a.textsRepo != nil {
@@ -198,5 +234,20 @@ func (a *App) ensureSettingsRepository() error {
 		return fmt.Errorf("settings repository: initialization failed: %w", err)
 	}
 	a.settingsRepo = repo
+	return nil
+}
+
+func (a *App) ensurePracticeRepository() error {
+	if a.practiceRepo != nil {
+		return nil
+	}
+	if a.storage == nil {
+		return fmt.Errorf("practice repository: storage manager not initialized")
+	}
+	repo, err := storage.NewPracticeGroupRepository(a.storage)
+	if err != nil {
+		return fmt.Errorf("practice repository: initialization failed: %w", err)
+	}
+	a.practiceRepo = repo
 	return nil
 }

--- a/app/app_practice_test.go
+++ b/app/app_practice_test.go
@@ -59,7 +59,7 @@ func TestApp_AggregateKeyMistakes(t *testing.T) {
 func TestSessionPayload_PracticeMeta(t *testing.T) {
 	payload := &domain.SessionPayload{
 		SessionTextMeta: &domain.SessionTextMeta{Text: "qqq"},
-		PracticeSessionMeta: &domain.PracticeSessionMeta{
+		PracticeSessionMeta: domain.PracticeSessionMeta{
 			PracticeMode:      domain.PracticeModeTargeted,
 			PracticeGroupID:   "builtin-home-row",
 			PracticeGroupName: "Home row",

--- a/app/app_practice_test.go
+++ b/app/app_practice_test.go
@@ -1,0 +1,76 @@
+// Copyright 2025 Asher Buk
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/AshBuk/FingerGo
+
+package app
+
+import (
+	"testing"
+	"time"
+
+	domain "github.com/AshBuk/FingerGo/internal/domain"
+)
+
+func TestApp_PracticeGroups(t *testing.T) {
+	app := startApp(t, t.TempDir())
+
+	saved, err := app.SavePracticeGroup(&domain.PracticeGroup{
+		Name:     "Test group",
+		LayoutID: "en-qwerty",
+		Keys:     []string{"q", "w"},
+	})
+	if err != nil {
+		t.Fatalf("SavePracticeGroup: %v", err)
+	}
+
+	groups, err := app.GetPracticeGroups()
+	if err != nil {
+		t.Fatalf("GetPracticeGroups: %v", err)
+	}
+	if len(groups) != 1 {
+		t.Fatalf("got %d groups, want 1", len(groups))
+	}
+
+	if err := app.DeletePracticeGroup(saved.ID); err != nil {
+		t.Fatalf("DeletePracticeGroup: %v", err)
+	}
+}
+
+func TestApp_AggregateKeyMistakes(t *testing.T) {
+	app := startApp(t, t.TempDir())
+
+	payload := &domain.SessionPayload{
+		SessionTextMeta: &domain.SessionTextMeta{Text: "test"},
+		Mistakes:        map[string]int{"a": 2},
+	}
+	if err := app.SaveSession(payload); err != nil {
+		t.Fatalf("SaveSession: %v", err)
+	}
+
+	agg, err := app.AggregateKeyMistakes(10)
+	if err != nil {
+		t.Fatalf("AggregateKeyMistakes: %v", err)
+	}
+	if agg["a"] != 2 {
+		t.Errorf("a = %d, want 2", agg["a"])
+	}
+}
+
+func TestSessionPayload_PracticeMeta(t *testing.T) {
+	payload := &domain.SessionPayload{
+		SessionTextMeta: &domain.SessionTextMeta{Text: "qqq"},
+		PracticeSessionMeta: &domain.PracticeSessionMeta{
+			PracticeMode:      domain.PracticeModeTargeted,
+			PracticeGroupID:   "builtin-home-row",
+			PracticeGroupName: "Home row",
+			TargetKeys:        []string{"a", "s"},
+		},
+	}
+	session := payload.ToTypingSession(time.Now())
+	if session.PracticeMode != domain.PracticeModeTargeted {
+		t.Errorf("mode = %q", session.PracticeMode)
+	}
+	if len(session.TargetKeys) != 2 {
+		t.Errorf("targetKeys = %v", session.TargetKeys)
+	}
+}

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -40,6 +40,9 @@ func TestApp_Startup(t *testing.T) {
 		if app.settingsRepo == nil {
 			t.Error("settingsRepo not initialized")
 		}
+		if app.practiceRepo == nil {
+			t.Error("practiceRepo not initialized")
+		}
 	})
 
 	t.Run("is idempotent", func(t *testing.T) {

--- a/gui/src/index.html
+++ b/gui/src/index.html
@@ -13,6 +13,7 @@ https://github.com/AshBuk/FingerGo
         <link rel="stylesheet" href="styles/modals.css" />
         <link rel="stylesheet" href="styles/keyboard.css" />
         <link rel="stylesheet" href="styles/library.css" />
+        <link rel="stylesheet" href="styles/practice.css" />
         <link id="theme-css" rel="stylesheet" href="styles/theme-dark.css" />
     </head>
     <body class="theme-dark">
@@ -114,6 +115,19 @@ https://github.com/AshBuk/FingerGo
                 <line x1="6" x2="2" y1="12" y2="12" />
                 <line x1="12" x2="12" y1="6" y2="2" />
                 <line x1="12" x2="12" y1="22" y2="18" />
+            </symbol>
+            <symbol
+                id="icon-target"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+            >
+                <circle cx="12" cy="12" r="10" />
+                <circle cx="12" cy="12" r="6" />
+                <circle cx="12" cy="12" r="2" />
             </symbol>
             <symbol
                 id="icon-circle"
@@ -271,6 +285,28 @@ https://github.com/AshBuk/FingerGo
                     </svg>
                 </button>
                 <button
+                    id="targeted-practice-btn"
+                    class="top-action-button"
+                    aria-label="Targeted practice"
+                    title="Targeted practice (Ctrl+Alt+P)"
+                    type="button"
+                >
+                    <svg width="16" height="16" aria-hidden="true">
+                        <use href="#icon-target" />
+                    </svg>
+                </button>
+                <button
+                    id="custom-text-practice-btn"
+                    class="top-action-button"
+                    aria-label="Custom text practice"
+                    title="Paste custom text to practice"
+                    type="button"
+                >
+                    <svg width="16" height="16" aria-hidden="true">
+                        <use href="#icon-pencil" />
+                    </svg>
+                </button>
+                <button
                     id="reset-session"
                     class="top-action-button"
                     aria-label="Reset session"
@@ -282,6 +318,7 @@ https://github.com/AshBuk/FingerGo
             </div>
             <!-- Text Display Area -->
             <section id="text-area">
+                <div id="practice-banner" hidden aria-live="polite"></div>
                 <div id="text-display"></div>
                 <textarea
                     id="text-input"
@@ -427,9 +464,15 @@ https://github.com/AshBuk/FingerGo
         <script src="js/layouts.js"></script>
         <script src="js/keyboard.js"></script>
         <script src="js/typing.js"></script>
+        <script src="js/practice/wordlist-en.js"></script>
+        <script src="js/practice/builtin-groups.js"></script>
+        <script src="js/practice/exercise-generator.js"></script>
+        <script src="js/practice/practice-manager.js"></script>
         <!-- Modal system: core first, then type-specific renderers -->
         <script src="js/modals/core.js"></script>
         <script src="js/modals/session-summary.js"></script>
+        <script src="js/modals/targeted-practice.js"></script>
+        <script src="js/modals/custom-text-practice.js"></script>
         <script src="js/modals/color-settings.js"></script>
         <script src="js/modals/text-editor.js"></script>
         <script src="js/modals/error.js"></script>

--- a/gui/src/js/__tests__/exercise-generator.test.js
+++ b/gui/src/js/__tests__/exercise-generator.test.js
@@ -50,4 +50,35 @@ describe('ExerciseGenerator', () => {
         assert.ok(/q/i.test(result.text));
         assert.ok(result.stats.targetCharRatio > 0.1);
     });
+
+    it('home row words use only home row letters', () => {
+        const keys = ['a', 's', 'd', 'f', 'g', 'h', 'j', 'k', 'l', ';'];
+        const allowed = new Set(keys);
+        const result = ExerciseGenerator.generateExercise({
+            targetKeys: keys,
+            length: 200,
+            style: 'words',
+            seed: 42,
+        });
+        for (const ch of result.text.toLowerCase()) {
+            if (ch >= 'a' && ch <= 'z') {
+                assert.ok(allowed.has(ch), `unexpected letter "${ch}" in "${result.text.slice(0, 40)}..."`);
+            }
+        }
+        assert.ok(result.stats.targetCharRatio >= 0.55);
+    });
+
+    it('numbers style uses only digits', () => {
+        const keys = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
+        const result = ExerciseGenerator.generateExercise({
+            targetKeys: keys,
+            length: 120,
+            style: 'words',
+            seed: 7,
+        });
+        for (const ch of result.text) {
+            if (ch === ' ') continue;
+            assert.ok(/[0-9]/.test(ch), `non-digit "${ch}"`);
+        }
+    });
 });

--- a/gui/src/js/__tests__/exercise-generator.test.js
+++ b/gui/src/js/__tests__/exercise-generator.test.js
@@ -1,0 +1,53 @@
+// Copyright 2025 Asher Buk
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/AshBuk/FingerGo
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+globalThis.window = {};
+await import('../practice/wordlist-en.js');
+await import('../practice/exercise-generator.js');
+
+const { ExerciseGenerator } = globalThis.window;
+
+describe('ExerciseGenerator', () => {
+    it('produces deterministic output with the same seed', () => {
+        const opts = { targetKeys: ['q', 'a'], length: 200, style: 'words', seed: 42 };
+        const a = ExerciseGenerator.generateExercise(opts);
+        const b = ExerciseGenerator.generateExercise(opts);
+        assert.equal(a.text, b.text);
+    });
+
+    it('respects length bounds', () => {
+        const result = ExerciseGenerator.generateExercise({
+            targetKeys: ['e'],
+            length: 150,
+            style: 'random',
+            seed: 7,
+        });
+        assert.ok(result.text.length <= 150);
+        assert.ok(result.text.length >= 50);
+    });
+
+    it('repeat style cycles target keys', () => {
+        const result = ExerciseGenerator.generateExercise({
+            targetKeys: ['a', 'b'],
+            length: 20,
+            style: 'repeat',
+        });
+        assert.ok(result.text.includes('a'));
+        assert.ok(result.text.includes('b'));
+    });
+
+    it('includes target keys in words style', () => {
+        const result = ExerciseGenerator.generateExercise({
+            targetKeys: ['q'],
+            length: 300,
+            style: 'words',
+            seed: 99,
+        });
+        assert.ok(/q/i.test(result.text));
+        assert.ok(result.stats.targetCharRatio > 0.1);
+    });
+});

--- a/gui/src/js/app.js
+++ b/gui/src/js/app.js
@@ -27,6 +27,8 @@
         bind('stats-toggle', () => window.SettingsManager.toggleStatsBar());
         bind('keyboard-toggle', () => window.SettingsManager.toggleKeyboard());
         bind('reset-session', () => window.SessionManager.reset());
+        bind('targeted-practice-btn', () => window.PracticeManager?.openTargetedModal());
+        bind('custom-text-practice-btn', () => window.PracticeManager?.openCustomTextModal());
         bind('strict-mode-toggle', () => window.SettingsManager.toggleStrictMode());
         bind('zoom-in', () => window.SettingsManager.zoomIn());
         bind('zoom-out', () => window.SettingsManager.zoomOut());
@@ -131,6 +133,7 @@
         initialize().then(() => {
             window.ShortcutsManager?.init();
             window.LibraryManager?.init();
+            window.PracticeManager?.init();
             window.SessionManager?.setupTypingStart();
         });
     }
@@ -173,6 +176,7 @@
         Settings: window.SettingsManager,
         Session: window.SessionManager,
         Library: window.LibraryManager,
+        Practice: window.PracticeManager,
         Shortcuts: window.ShortcutsManager,
         Modal: window.ModalManager,
         App: window.App,

--- a/gui/src/js/modals/custom-text-practice.js
+++ b/gui/src/js/modals/custom-text-practice.js
@@ -1,0 +1,71 @@
+// Copyright 2025 Asher Buk
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/AshBuk/FingerGo
+
+/**
+ * Custom text practice modal: paste ephemeral text and start typing.
+ */
+(() => {
+    if (!window.ModalManager) return;
+
+    const esc = window.AppUtils?.escapeHtml || (s => String(s ?? ''));
+
+    function render() {
+        return `<div class="custom-text-practice">
+            <p class="practice-muted">Paste any text to practice. It is not saved unless you add it to the library.</p>
+            <label for="custom-practice-input">Text</label>
+            <textarea id="custom-practice-input" rows="10" placeholder="Paste or type text here…"></textarea>
+            <p class="practice-muted">Preview</p>
+            <div id="custom-practice-preview" class="practice-preview practice-preview-box"> </div>
+            <div class="practice-modal-actions">
+                <button type="button" id="custom-practice-save-library">Save to library…</button>
+                <button type="button" id="custom-practice-start">Start practice</button>
+            </div>
+        </div>`;
+    }
+
+    function bind(_data, container) {
+        const input = container.querySelector('#custom-practice-input');
+        const preview = container.querySelector('#custom-practice-preview');
+        const updatePreview = () => {
+            const text = input?.value || '';
+            const snippet = esc(text.slice(0, 200));
+            if (preview) {
+                preview.textContent = '';
+                preview.innerHTML = snippet + (text.length > 200 ? '…' : '') || ' ';
+            }
+        };
+        input?.addEventListener('input', updatePreview);
+
+        container.querySelector('#custom-practice-start')?.addEventListener('click', () => {
+            const text = input?.value || '';
+            if (!text.trim()) return;
+            window.PracticeManager?.startCustomText(text);
+        });
+
+        container.querySelector('#custom-practice-save-library')?.addEventListener('click', async () => {
+            const text = (input?.value || '').trim();
+            if (!text) return;
+            const firstLine = text.split('\n')[0].trim().slice(0, 64) || 'Custom text';
+            let categories = [];
+            try {
+                const lib = await window.go?.app?.App?.TextLibrary?.();
+                categories = lib?.categories || [];
+            } catch {
+                /* ignore */
+            }
+            window.ModalManager?.show('text-editor', {
+                mode: 'create',
+                text: { title: firstLine, content: text, language: 'text' },
+                categories,
+                selectedCategory: null,
+            });
+        });
+    }
+
+    window.ModalManager.registerType('custom-text-practice', {
+        title: 'Custom Text Practice',
+        render,
+        bind,
+    });
+})();

--- a/gui/src/js/modals/session-summary.js
+++ b/gui/src/js/modals/session-summary.js
@@ -62,10 +62,23 @@
      * @param {Object} data - Session data
      * @returns {string} HTML content
      */
+    function renderPracticeInfo(data) {
+        const mode = data?.practiceMode;
+        if (!mode) return '';
+        const name = data.practiceGroupName || (mode === 'custom-text' ? 'Custom text' : 'Targeted');
+        const keys = Array.isArray(data.targetKeys) ? data.targetKeys : [];
+        const keysLine =
+            keys.length > 0
+                ? `<p class="practice-summary-keys">Keys: ${keys.map(k => esc(formatKeyLabel(k))).join(', ')}</p>`
+                : '';
+        return `<div class="summary-practice"><h4>Practice: ${esc(name)}</h4><p class="practice-summary-mode">${esc(mode)}</p>${keysLine}</div>`;
+    }
+
     function render(data) {
         if (!data) return '<p>No session data</p>';
         return `
             <div class="session-summary">
+                ${renderPracticeInfo(data)}
                 <div class="summary-stats">
                     <div class="summary-stat">
                         <span class="summary-label">WPM</span>
@@ -91,6 +104,7 @@
                         <h3>Errors: ${data.totalErrors}</h3>
                         <p>Total keystrokes: ${data.totalKeystrokes || 0}</p>
                         ${renderMistakeList(data.mistakes)}
+                        <p><button type="button" id="summary-targeted-practice" class="practice-link-btn">Practice weak keys</button></p>
                     </div>
                 `
                         : ''
@@ -108,9 +122,17 @@
         return data?.isCompleted ? 'Session Complete' : 'Session Paused';
     }
 
+    function bind(_data, container) {
+        container.querySelector('#summary-targeted-practice')?.addEventListener('click', () => {
+            window.ModalManager?.hide();
+            window.PracticeManager?.openTargetedModal();
+        });
+    }
+
     // Register with ModalManager
     window.ModalManager.registerType('session-summary', {
         title: getTitle,
         render,
+        bind,
     });
 })();

--- a/gui/src/js/modals/targeted-practice.js
+++ b/gui/src/js/modals/targeted-practice.js
@@ -115,6 +115,16 @@
     function render(data) {
         if (state.editingGroup !== null) return renderEditor();
         const builtins = PM().getBuiltinGroups();
+        let builtinCards = builtins.map(g => renderGroupCard({ ...g, source: 'builtin' }));
+        if (state.weakKeys.length) {
+            const weakGroup = {
+                id: 'builtin-weak-keys',
+                name: 'Weak keys',
+                keys: state.weakKeys.map(([k]) => k),
+                source: 'suggested',
+            };
+            builtinCards = [renderGroupCard(weakGroup), ...builtinCards];
+        }
         return `<div class="targeted-practice">
             <section class="practice-section">
                 <h4>Suggested weak keys</h4>
@@ -122,7 +132,7 @@
             </section>
             <section class="practice-section">
                 <h4>Built-in groups</h4>
-                <div class="practice-group-grid">${builtins.map(g => renderGroupCard({ ...g, source: 'builtin' })).join('')}</div>
+                <div class="practice-group-grid">${builtinCards.join('')}</div>
             </section>
             <section class="practice-section">
                 <h4>Custom groups <button type="button" class="practice-link-btn" id="practice-new-group">+ New group</button></h4>

--- a/gui/src/js/modals/targeted-practice.js
+++ b/gui/src/js/modals/targeted-practice.js
@@ -1,0 +1,301 @@
+// Copyright 2025 Asher Buk
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/AshBuk/FingerGo
+
+/**
+ * Targeted practice modal: groups, weak-key suggestions, exercise generation.
+ */
+(() => {
+    if (!window.ModalManager) return;
+
+    const esc = window.PracticeManager?.esc || (s => String(s ?? ''));
+    const PM = () => window.PracticeManager;
+
+    const state = {
+        selectedGroup: null,
+        length: 300,
+        style: 'words',
+        previewSeed: 1,
+        weakKeys: [],
+        customGroups: [],
+        editingGroup: null,
+        pickerKeys: new Set(),
+    };
+
+    function formatKeyLabel(key) {
+        if (key === ' ') return 'Space';
+        return key;
+    }
+
+    function renderPreview() {
+        if (!state.selectedGroup?.keys?.length) return '<p class="practice-muted">Select a group to preview.</p>';
+        const result = window.ExerciseGenerator?.generateExercise({
+            targetKeys: state.selectedGroup.keys,
+            length: state.length,
+            style: state.style,
+            seed: state.previewSeed,
+        });
+        const preview = esc((result?.text || '').slice(0, 160));
+        return `<p class="practice-preview">${preview}${(result?.text?.length || 0) > 160 ? '…' : ''}</p>`;
+    }
+
+    function renderGroupCard(group, extraClass = '') {
+        const keysPreview = esc(group.keys.slice(0, 14).join(' '));
+        const selected = state.selectedGroup?.id === group.id ? ' selected' : '';
+        const isCustom = group.source === 'custom';
+        const editBtn = isCustom
+            ? `<button type="button" class="practice-group-edit" data-edit-id="${esc(group.id)}" title="Edit">✎</button>`
+            : '';
+        return `<div role="button" tabindex="0" class="practice-group-card${selected}${extraClass}" data-group-id="${esc(group.id)}" data-source="${esc(group.source || 'builtin')}">
+            <span class="practice-group-name">${esc(group.name)}</span>
+            <span class="practice-group-keys">${keysPreview}${group.keys.length > 14 ? '…' : ''}</span>
+            ${editBtn}
+        </div>`;
+    }
+
+    async function refreshData() {
+        state.weakKeys = await PM().fetchWeakKeys(50);
+        state.customGroups = await PM().fetchCustomGroups();
+    }
+
+    function renderWeakSection() {
+        if (!state.weakKeys.length) {
+            return '<p class="practice-muted">Complete typing sessions to see weak-key suggestions.</p>';
+        }
+        const chips = state.weakKeys
+            .map(([key, count]) => `<span class="weak-key-chip">${esc(formatKeyLabel(key))} <em>${count}</em></span>`)
+            .join('');
+        return `<div class="weak-keys-row">${chips}
+            <button type="button" class="practice-link-btn" id="practice-weak-start">Practice these keys</button>
+        </div>`;
+    }
+
+    function renderCustomSection() {
+        if (!state.customGroups.length) {
+            return '<p class="practice-muted">No custom groups yet.</p>';
+        }
+        return state.customGroups
+            .map(g =>
+                renderGroupCard(
+                    { ...g, id: g.id, name: g.name, keys: g.keys, source: 'custom' },
+                    ' custom',
+                ),
+            )
+            .join('');
+    }
+
+    function renderEditor() {
+        const name = esc(state.editingGroup?.name || '');
+        const selected = [...state.pickerKeys].map(k => esc(formatKeyLabel(k))).join(', ');
+        const layout = PM().getBuiltinGroups()[0]?.layoutId || PM().getLayoutId();
+        const layoutObj =
+            window.KeyboardLayouts?.getLayout?.(layout) ||
+            window.KeyboardLayouts?.getDefaultLayout?.();
+        const keys = layoutObj?.fingerMap ? Object.keys(layoutObj.fingerMap) : [];
+        const keyButtons = keys
+            .filter(k => !['Tab', 'CapsLock', 'Backspace', 'Enter'].includes(k))
+            .slice(0, 80)
+            .map(k => {
+                const on = state.pickerKeys.has(k) ? ' active' : '';
+                return `<button type="button" class="key-pick-btn${on}" data-key="${esc(k)}">${esc(formatKeyLabel(k))}</button>`;
+            })
+            .join('');
+        return `<div class="practice-editor">
+            <h4>${state.editingGroup?.id ? 'Edit' : 'New'} custom group</h4>
+            <label>Name <input type="text" id="practice-group-name" value="${name}" maxlength="64"></label>
+            <p class="practice-muted">Selected: <span id="practice-selected-keys">${selected || 'none'}</span></p>
+            <div class="key-picker-grid">${keyButtons}</div>
+            <div class="practice-editor-actions">
+                <button type="button" id="practice-editor-cancel">Cancel</button>
+                <button type="button" id="practice-editor-save">Save group</button>
+            </div>
+        </div>`;
+    }
+
+    function render(data) {
+        if (state.editingGroup !== null) return renderEditor();
+        const builtins = PM().getBuiltinGroups();
+        return `<div class="targeted-practice">
+            <section class="practice-section">
+                <h4>Suggested weak keys</h4>
+                ${renderWeakSection()}
+            </section>
+            <section class="practice-section">
+                <h4>Built-in groups</h4>
+                <div class="practice-group-grid">${builtins.map(g => renderGroupCard({ ...g, source: 'builtin' })).join('')}</div>
+            </section>
+            <section class="practice-section">
+                <h4>Custom groups <button type="button" class="practice-link-btn" id="practice-new-group">+ New group</button></h4>
+                <div class="practice-group-grid custom-groups">${renderCustomSection()}</div>
+            </section>
+            <section class="practice-section">
+                <h4>Exercise</h4>
+                <div class="practice-options">
+                    <label>Length <input type="number" id="practice-length" min="100" max="2000" value="${state.length}"></label>
+                    <label>Style
+                        <select id="practice-style">
+                            <option value="words"${state.style === 'words' ? ' selected' : ''}>Words</option>
+                            <option value="random"${state.style === 'random' ? ' selected' : ''}>Random</option>
+                            <option value="repeat"${state.style === 'repeat' ? ' selected' : ''}>Repeat</option>
+                        </select>
+                    </label>
+                    <button type="button" id="practice-regenerate-preview">Regenerate preview</button>
+                </div>
+                ${renderPreview()}
+            </section>
+            <div class="practice-modal-actions">
+                <button type="button" id="practice-start" ${state.selectedGroup ? '' : 'disabled'}>Start practice</button>
+            </div>
+        </div>`;
+    }
+
+    function selectGroup(group) {
+        state.selectedGroup = group;
+        state.previewSeed++;
+    }
+
+    function resolveGroup(id, source) {
+        if (source === 'custom') {
+            const g = state.customGroups.find(x => x.id === id);
+            return g ? { id: g.id, name: g.name, keys: g.keys, source: 'custom' } : null;
+        }
+        return window.BuiltinPracticeGroups?.getBuiltinGroup?.(id, PM().getLayoutId());
+    }
+
+    function bind(data, container) {
+        const rerender = () => {
+            window.ModalManager.show('targeted-practice', data);
+        };
+
+        if (state.editingGroup !== null) {
+            container.querySelectorAll('.key-pick-btn').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    const key = btn.dataset.key;
+                    if (state.pickerKeys.has(key)) state.pickerKeys.delete(key);
+                    else state.pickerKeys.add(key);
+                    rerender();
+                });
+            });
+            container.querySelector('#practice-editor-cancel')?.addEventListener('click', () => {
+                state.editingGroup = null;
+                state.pickerKeys.clear();
+                rerender();
+            });
+            container.querySelector('#practice-editor-save')?.addEventListener('click', async () => {
+                const name = container.querySelector('#practice-group-name')?.value?.trim();
+                if (!name || state.pickerKeys.size === 0) return;
+                const group = {
+                    id: state.editingGroup?.id || '',
+                    name,
+                    layoutId: PM().getLayoutId(),
+                    keys: [...state.pickerKeys],
+                };
+                try {
+                    await PM().saveCustomGroup(group);
+                    state.editingGroup = null;
+                    state.pickerKeys.clear();
+                    await refreshData();
+                    rerender();
+                } catch (err) {
+                    console.error('Save practice group failed:', err);
+                }
+            });
+            return;
+        }
+
+        container.querySelector('#practice-weak-start')?.addEventListener('click', () => {
+            const keys = state.weakKeys.map(([k]) => k);
+            if (!keys.length) return;
+            selectGroup({
+                id: 'suggested-weak-keys',
+                name: 'Weak keys',
+                keys,
+                source: 'suggested',
+            });
+            PM().startTargeted(state.selectedGroup, {
+                length: state.length,
+                style: state.style,
+            });
+        });
+
+        container.querySelectorAll('.practice-group-card').forEach(card => {
+            card.addEventListener('click', e => {
+                if (e.target.closest('.practice-group-edit')) return;
+                const group = resolveGroup(card.dataset.groupId, card.dataset.source);
+                if (group) selectGroup(group);
+                rerender();
+            });
+            card.addEventListener('keydown', e => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    card.click();
+                }
+            });
+        });
+
+        container.querySelectorAll('.practice-group-edit').forEach(btn => {
+            btn.addEventListener('click', e => {
+                e.stopPropagation();
+                const g = state.customGroups.find(x => x.id === btn.dataset.editId);
+                if (!g) return;
+                state.editingGroup = { id: g.id };
+                state.pickerKeys = new Set(g.keys);
+                rerender();
+            });
+        });
+
+        container.querySelectorAll('.custom-groups .practice-group-card').forEach(card => {
+            card.addEventListener('contextmenu', e => {
+                e.preventDefault();
+                const id = card.dataset.groupId;
+                if (confirm('Delete this custom group?')) {
+                    PM()
+                        .deleteCustomGroup(id)
+                        .then(() => refreshData().then(rerender));
+                }
+            });
+        });
+
+        container.querySelector('#practice-new-group')?.addEventListener('click', () => {
+            state.editingGroup = {};
+            state.pickerKeys.clear();
+            rerender();
+        });
+
+        container.querySelector('#practice-length')?.addEventListener('change', e => {
+            state.length = Number(e.target.value) || 300;
+            state.previewSeed++;
+        });
+        container.querySelector('#practice-style')?.addEventListener('change', e => {
+            state.style = e.target.value;
+            state.previewSeed++;
+        });
+        container.querySelector('#practice-regenerate-preview')?.addEventListener('click', () => {
+            state.previewSeed++;
+            rerender();
+        });
+
+        container.querySelector('#practice-start')?.addEventListener('click', () => {
+            if (!state.selectedGroup) return;
+            PM().startTargeted(state.selectedGroup, {
+                length: state.length,
+                style: state.style,
+                seed: Date.now(),
+            });
+        });
+    }
+
+    window.ModalManager.registerType('targeted-practice', {
+        title: 'Targeted Practice',
+        render,
+        bind(data, container) {
+            bind(data, container);
+            refreshData().then(() => {
+                const overlay = document.getElementById('modal-overlay');
+                if (overlay && !overlay.classList.contains('modal-hidden')) {
+                    window.ModalManager.show('targeted-practice', data);
+                }
+            });
+        },
+    });
+})();

--- a/gui/src/js/modals/targeted-practice.js
+++ b/gui/src/js/modals/targeted-practice.js
@@ -10,6 +10,10 @@
 
     const esc = window.PracticeManager?.esc || (s => String(s ?? ''));
     const PM = () => window.PracticeManager;
+    const DEBUG = false;
+    const log = (...args) => {
+        if (DEBUG) console.log('[TargetedPractice]', ...args);
+    };
 
     const state = {
         selectedGroup: null,
@@ -20,6 +24,8 @@
         customGroups: [],
         editingGroup: null,
         pickerKeys: new Set(),
+        groupCache: new Map(),
+        dataLoaded: false,
     };
 
     function formatKeyLabel(key) {
@@ -27,8 +33,35 @@
         return key;
     }
 
+    function rebuildGroupCache() {
+        state.groupCache.clear();
+        const add = group => {
+            if (!group?.id) return;
+            const source = group.source || 'builtin';
+            state.groupCache.set(`${source}:${group.id}`, { ...group, keys: [...(group.keys || [])] });
+        };
+        PM().getBuiltinGroups().forEach(add);
+        state.customGroups.forEach(g => add({ ...g, source: 'custom' }));
+        if (state.weakKeys.length) {
+            add({
+                id: 'builtin-weak-keys',
+                name: 'Weak keys',
+                keys: state.weakKeys.map(([k]) => k),
+                source: 'suggested',
+            });
+        }
+    }
+
+    function resolveGroupFromCard(card) {
+        const key = `${card.dataset.source}:${card.dataset.groupId}`;
+        return state.groupCache.get(key) || null;
+    }
+
     function renderPreview() {
-        if (!state.selectedGroup?.keys?.length) return '<p class="practice-muted">Select a group to preview.</p>';
+        if (!state.selectedGroup?.keys?.length) {
+            return '<p class="practice-muted">Select a group to preview.</p>';
+        }
+        log('preview', state.selectedGroup.id, state.selectedGroup.keys.length);
         const result = window.ExerciseGenerator?.generateExercise({
             targetKeys: state.selectedGroup.keys,
             length: state.length,
@@ -56,6 +89,7 @@
     async function refreshData() {
         state.weakKeys = await PM().fetchWeakKeys(50);
         state.customGroups = await PM().fetchCustomGroups();
+        rebuildGroupCache();
     }
 
     function renderWeakSection() {
@@ -87,7 +121,7 @@
     function renderEditor() {
         const name = esc(state.editingGroup?.name || '');
         const selected = [...state.pickerKeys].map(k => esc(formatKeyLabel(k))).join(', ');
-        const layout = PM().getBuiltinGroups()[0]?.layoutId || PM().getLayoutId();
+        const layout = PM().getLayoutId();
         const layoutObj =
             window.KeyboardLayouts?.getLayout?.(layout) ||
             window.KeyboardLayouts?.getDefaultLayout?.();
@@ -112,18 +146,14 @@
         </div>`;
     }
 
-    function render(data) {
+    function render() {
         if (state.editingGroup !== null) return renderEditor();
-        const builtins = PM().getBuiltinGroups();
-        let builtinCards = builtins.map(g => renderGroupCard({ ...g, source: 'builtin' }));
-        if (state.weakKeys.length) {
-            const weakGroup = {
-                id: 'builtin-weak-keys',
-                name: 'Weak keys',
-                keys: state.weakKeys.map(([k]) => k),
-                source: 'suggested',
-            };
-            builtinCards = [renderGroupCard(weakGroup), ...builtinCards];
+        rebuildGroupCache();
+        const builtins = [...state.groupCache.values()].filter(g => g.source === 'builtin');
+        const suggested = state.groupCache.get('suggested:builtin-weak-keys');
+        let builtinCards = builtins.map(g => renderGroupCard(g));
+        if (suggested) {
+            builtinCards = [renderGroupCard(suggested), ...builtinCards];
         }
         return `<div class="targeted-practice">
             <section class="practice-section">
@@ -132,11 +162,11 @@
             </section>
             <section class="practice-section">
                 <h4>Built-in groups</h4>
-                <div class="practice-group-grid">${builtinCards.join('')}</div>
+                <div class="practice-group-grid" id="practice-builtin-grid">${builtinCards.join('')}</div>
             </section>
             <section class="practice-section">
                 <h4>Custom groups <button type="button" class="practice-link-btn" id="practice-new-group">+ New group</button></h4>
-                <div class="practice-group-grid custom-groups">${renderCustomSection()}</div>
+                <div class="practice-group-grid custom-groups" id="practice-custom-grid">${renderCustomSection()}</div>
             </section>
             <section class="practice-section">
                 <h4>Exercise</h4>
@@ -154,29 +184,40 @@
                 ${renderPreview()}
             </section>
             <div class="practice-modal-actions">
-                <button type="button" id="practice-start" ${state.selectedGroup ? '' : 'disabled'}>Start practice</button>
+                <button type="button" id="practice-start"${state.selectedGroup ? '' : ' disabled'}>Start practice</button>
             </div>
         </div>`;
     }
 
     function selectGroup(group) {
-        state.selectedGroup = group;
-        state.previewSeed++;
-    }
-
-    function resolveGroup(id, source) {
-        if (source === 'custom') {
-            const g = state.customGroups.find(x => x.id === id);
-            return g ? { id: g.id, name: g.name, keys: g.keys, source: 'custom' } : null;
+        if (!group?.keys?.length) {
+            log('selectGroup rejected: no keys', group);
+            return;
         }
-        return window.BuiltinPracticeGroups?.getBuiltinGroup?.(id, PM().getLayoutId());
+        state.selectedGroup = {
+            id: group.id,
+            name: group.name,
+            keys: [...group.keys],
+            source: group.source,
+        };
+        state.previewSeed++;
+        log('selectGroup', state.selectedGroup.id, state.selectedGroup.keys.length);
     }
 
-    function bind(data, container) {
-        const rerender = () => {
-            window.ModalManager.show('targeted-practice', data);
-        };
+    function paint(container) {
+        if (!container) return;
+        container.innerHTML = render();
+        bindHandlers(container);
+    }
 
+    function rerender() {
+        const container = document.getElementById('modal-content');
+        const overlay = document.getElementById('modal-overlay');
+        if (!container || overlay?.classList.contains('modal-hidden')) return;
+        paint(container);
+    }
+
+    function bindHandlers(container) {
         if (state.editingGroup !== null) {
             container.querySelectorAll('.key-pick-btn').forEach(btn => {
                 btn.addEventListener('click', () => {
@@ -214,25 +255,23 @@
         }
 
         container.querySelector('#practice-weak-start')?.addEventListener('click', () => {
-            const keys = state.weakKeys.map(([k]) => k);
-            if (!keys.length) return;
-            selectGroup({
-                id: 'suggested-weak-keys',
-                name: 'Weak keys',
-                keys,
-                source: 'suggested',
-            });
-            PM().startTargeted(state.selectedGroup, {
+            const group = state.groupCache.get('suggested:builtin-weak-keys');
+            if (!group?.keys?.length) return;
+            log('weak-start', group.keys);
+            PM().startTargeted(group, {
                 length: state.length,
                 style: state.style,
+                seed: Date.now(),
             });
         });
 
         container.querySelectorAll('.practice-group-card').forEach(card => {
             card.addEventListener('click', e => {
                 if (e.target.closest('.practice-group-edit')) return;
-                const group = resolveGroup(card.dataset.groupId, card.dataset.source);
-                if (group) selectGroup(group);
+                const group = resolveGroupFromCard(card);
+                log('card click', card.dataset.source, card.dataset.groupId, Boolean(group));
+                if (!group) return;
+                selectGroup(group);
                 rerender();
             });
             card.addEventListener('keydown', e => {
@@ -261,7 +300,11 @@
                 if (confirm('Delete this custom group?')) {
                     PM()
                         .deleteCustomGroup(id)
-                        .then(() => refreshData().then(rerender));
+                        .then(async () => {
+                            await refreshData();
+                            if (state.selectedGroup?.id === id) state.selectedGroup = null;
+                            rerender();
+                        });
                 }
             });
         });
@@ -275,10 +318,12 @@
         container.querySelector('#practice-length')?.addEventListener('change', e => {
             state.length = Number(e.target.value) || 300;
             state.previewSeed++;
+            rerender();
         });
         container.querySelector('#practice-style')?.addEventListener('change', e => {
             state.style = e.target.value;
             state.previewSeed++;
+            rerender();
         });
         container.querySelector('#practice-regenerate-preview')?.addEventListener('click', () => {
             state.previewSeed++;
@@ -286,7 +331,11 @@
         });
 
         container.querySelector('#practice-start')?.addEventListener('click', () => {
-            if (!state.selectedGroup) return;
+            if (!state.selectedGroup?.keys?.length) {
+                log('start blocked: no selection');
+                return;
+            }
+            log('start practice', state.selectedGroup.id);
             PM().startTargeted(state.selectedGroup, {
                 length: state.length,
                 style: state.style,
@@ -295,17 +344,27 @@
         });
     }
 
+    window.EventBus?.on('modal:closed', () => {
+        state.dataLoaded = false;
+    });
+
     window.ModalManager.registerType('targeted-practice', {
         title: 'Targeted Practice',
-        render,
-        bind(data, container) {
-            bind(data, container);
-            refreshData().then(() => {
-                const overlay = document.getElementById('modal-overlay');
-                if (overlay && !overlay.classList.contains('modal-hidden')) {
-                    window.ModalManager.show('targeted-practice', data);
-                }
-            });
+        render: () => render(),
+        bind(_data, container) {
+            rebuildGroupCache();
+            bindHandlers(container);
+            if (!state.dataLoaded) {
+                state.dataLoaded = true;
+                refreshData()
+                    .then(() => {
+                        const overlay = document.getElementById('modal-overlay');
+                        if (!overlay?.classList.contains('modal-hidden')) {
+                            paint(container);
+                        }
+                    })
+                    .catch(err => console.error('Targeted practice: refresh failed', err));
+            }
         },
     });
 })();

--- a/gui/src/js/modals/text-editor.js
+++ b/gui/src/js/modals/text-editor.js
@@ -22,9 +22,9 @@
     function render(data) {
         const { mode, text, categories, selectedCategory } = data;
         const isEdit = mode === 'edit' && text;
-        const title = esc(isEdit ? text.title : '');
-        const content = esc(isEdit ? text.content : '');
-        const language = esc(isEdit ? text.language || 'text' : 'text');
+        const title = esc(isEdit ? text.title : text?.title || '');
+        const content = esc(isEdit ? text.content : text?.content || '');
+        const language = esc(isEdit ? text.language || 'text' : text?.language || 'text');
         const categoryId = isEdit ? text.categoryId : selectedCategory || '';
 
         // Find current category name for display

--- a/gui/src/js/practice/builtin-groups.js
+++ b/gui/src/js/practice/builtin-groups.js
@@ -1,0 +1,137 @@
+// Copyright 2025 Asher Buk
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/AshBuk/FingerGo
+
+/**
+ * Built-in targeted practice groups derived from keyboard layouts.
+ */
+(() => {
+    const HOME_ROW_KEYS = new Set(['a', 's', 'd', 'f', 'g', 'h', 'j', 'k', 'l', ';']);
+    const NUMBER_KEYS = new Set(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']);
+    const PUNCTUATION_KEYS = new Set([';', "'", ',', '.', '/']);
+    const MODIFIER_KEYS = new Set([
+        'Tab', 'CapsLock', 'Shift', 'Control', 'Alt', 'Meta', 'Backspace', 'Enter',
+    ]);
+
+    function uniqueSorted(keys) {
+        return [...new Set(keys)].sort((a, b) => a.localeCompare(b));
+    }
+
+    function keysFromFingerMap(layout, predicate) {
+        if (!layout?.fingerMap) return [];
+        return uniqueSorted(
+            Object.entries(layout.fingerMap)
+                .filter(([key, finger]) => predicate(key, finger))
+                .map(([key]) => key),
+        );
+    }
+
+    function resolveTopRow(layout) {
+        return keysFromFingerMap(
+            layout,
+            (key, finger) =>
+                NUMBER_KEYS.has(key) ||
+                (key.length === 1 &&
+                    key >= 'q' &&
+                    key <= 'p' &&
+                    typeof finger === 'string' &&
+                    finger.includes('index')),
+        );
+    }
+
+    function resolveBottomRow(layout) {
+        return keysFromFingerMap(
+            layout,
+            (key, finger) =>
+                (key.length === 1 &&
+                    key >= 'z' &&
+                    key <= 'm' &&
+                    typeof finger === 'string') ||
+                (PUNCTUATION_KEYS.has(key) && finger?.startsWith?.('right')),
+        );
+    }
+
+    function resolveSymbols(layout) {
+        const symbols = keysFromFingerMap(
+            layout,
+            (key, finger) =>
+                key.length === 1 &&
+                !NUMBER_KEYS.has(key) &&
+                !HOME_ROW_KEYS.has(key) &&
+                !PUNCTUATION_KEYS.has(key) &&
+                key !== ' ' &&
+                !MODIFIER_KEYS.has(key) &&
+                (layout.shiftToBaseKey?.[key] !== undefined ||
+                    (finger && !finger.includes('pinky') && key === key.toUpperCase())),
+        );
+        if (layout.shiftToBaseKey) {
+            Object.keys(layout.shiftToBaseKey).forEach(sym => {
+                if (!symbols.includes(sym)) symbols.push(sym);
+            });
+        }
+        return uniqueSorted(symbols);
+    }
+
+    const BUILTIN_DEFS = [
+        { id: 'builtin-home-row', name: 'Home row', resolve: () => uniqueSorted([...HOME_ROW_KEYS]) },
+        {
+            id: 'builtin-left-hand',
+            name: 'Left hand',
+            resolve: layout =>
+                keysFromFingerMap(layout, (_, finger) => finger?.startsWith?.('left-')),
+        },
+        {
+            id: 'builtin-right-hand',
+            name: 'Right hand',
+            resolve: layout =>
+                keysFromFingerMap(layout, (_, finger) => finger?.startsWith?.('right-')),
+        },
+        { id: 'builtin-top-row', name: 'Top row', resolve: resolveTopRow },
+        { id: 'builtin-bottom-row', name: 'Bottom row', resolve: resolveBottomRow },
+        {
+            id: 'builtin-numbers',
+            name: 'Numbers',
+            resolve: layout => keysFromFingerMap(layout, key => NUMBER_KEYS.has(key)),
+        },
+        {
+            id: 'builtin-punctuation',
+            name: 'Punctuation',
+            resolve: layout => keysFromFingerMap(layout, key => PUNCTUATION_KEYS.has(key)),
+        },
+        { id: 'builtin-symbols', name: 'Symbols', resolve: resolveSymbols },
+    ];
+
+    /**
+     * @param {string} [layoutId]
+     * @returns {Array<{id: string, name: string, layoutId: string, keys: string[], source: string}>}
+     */
+    function getBuiltinGroups(layoutId) {
+        const layout =
+            window.KeyboardLayouts?.getLayout?.(layoutId) ||
+            window.KeyboardLayouts?.getDefaultLayout?.();
+        const id = layout?.id || layoutId || 'en-qwerty';
+        return BUILTIN_DEFS.map(def => {
+            const keys = def.resolve(layout || { fingerMap: {} });
+            return {
+                id: def.id,
+                name: def.name,
+                layoutId: id,
+                keys,
+                source: 'builtin',
+            };
+        }).filter(g => g.keys.length > 0);
+    }
+
+    /**
+     * @param {string} groupId
+     * @param {string} [layoutId]
+     */
+    function getBuiltinGroup(groupId, layoutId) {
+        return getBuiltinGroups(layoutId).find(g => g.id === groupId) || null;
+    }
+
+    window.BuiltinPracticeGroups = {
+        getBuiltinGroups,
+        getBuiltinGroup,
+    };
+})();

--- a/gui/src/js/practice/exercise-generator.js
+++ b/gui/src/js/practice/exercise-generator.js
@@ -1,0 +1,188 @@
+// Copyright 2025 Asher Buk
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/AshBuk/FingerGo
+
+/**
+ * Generates targeted practice text from a set of keys.
+ */
+(() => {
+    const DEFAULT_LENGTH = 300;
+    const MIN_LENGTH = 100;
+    const MAX_LENGTH = 2000;
+
+    /**
+     * @param {number} seed
+     * @returns {() => number}
+     */
+    function createRng(seed) {
+        let s = (seed >>> 0) || 1;
+        return () => {
+            s = (s + 0x6d2b79f5) >>> 0;
+            let t = s;
+            t = Math.imul(t ^ (t >>> 15), t | 1);
+            t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+            return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+        };
+    }
+
+    /**
+     * @param {() => number} rng
+     * @param {string[]} items
+     */
+    function pick(rng, items) {
+        if (!items.length) return '';
+        return items[Math.floor(rng() * items.length)];
+    }
+
+    /**
+     * @param {string[]} targetKeys
+     * @returns {boolean}
+     */
+    function wordMatches(word, targetKeys) {
+        const lower = word.toLowerCase();
+        return targetKeys.some(k => {
+            if (k === ' ') return lower.includes(' ');
+            if (k.length !== 1) return false;
+            return lower.includes(k);
+        });
+    }
+
+    /**
+     * @param {string[]} targetKeys
+     */
+    function countTargetChars(text, targetKeys) {
+        const set = new Set(targetKeys.map(k => (k === ' ' ? ' ' : k.toLowerCase())));
+        let hits = 0;
+        for (const ch of text) {
+            const c = ch === ' ' ? ' ' : ch.toLowerCase();
+            if (set.has(c)) hits++;
+        }
+        return hits;
+    }
+
+    /**
+     * @param {string[]} targetKeys
+     * @param {() => number} rng
+     */
+    function buildEmphasisChunk(targetKeys, rng) {
+        const key = pick(rng, targetKeys.filter(k => k !== 'Enter' && k !== 'Tab'));
+        if (!key || key === ' ') return '   ';
+        if (key.length === 1) {
+            const rep = 2 + Math.floor(rng() * 2);
+            return `${key.repeat(rep)} `;
+        }
+        return `${key} `;
+    }
+
+    /**
+     * @param {Object} options
+     * @param {string[]} options.targetKeys
+     * @param {number} [options.length]
+     * @param {string} [options.style] words | random | repeat
+     * @param {number} [options.seed]
+     */
+    function generateWords(options, rng) {
+        const targetKeys = options.targetKeys || [];
+        const words = window.PracticeWordlistEN || [];
+        const targetWords = words.filter(w => wordMatches(w, targetKeys));
+        const pool = targetWords.length > 0 ? targetWords : words;
+        const weighted = [];
+        pool.forEach(w => {
+            const weight = wordMatches(w, targetKeys) ? 3 : 1;
+            for (let i = 0; i < weight; i++) weighted.push(w);
+        });
+        const filler = words.filter(w => !wordMatches(w, targetKeys));
+        let text = '';
+        while (text.length < (options.length || DEFAULT_LENGTH)) {
+            const roll = rng();
+            if (roll < 0.2) {
+                text += buildEmphasisChunk(targetKeys, rng);
+            } else if (roll < 0.9) {
+                text += `${pick(rng, weighted)} `;
+            } else if (filler.length) {
+                text += `${pick(rng, filler)} `;
+            } else {
+                text += `${pick(rng, weighted)} `;
+            }
+        }
+        return text.trim();
+    }
+
+    function generateRandom(options, rng) {
+        const keys = (options.targetKeys || []).filter(k => k && k !== 'Enter' && k !== 'Tab');
+        const chars = keys.length ? keys : ['a'];
+        let text = '';
+        while (text.length < (options.length || DEFAULT_LENGTH)) {
+            const key = pick(rng, chars);
+            text += key === ' ' ? ' ' : key.length === 1 ? key : `${key} `;
+            if (rng() < 0.14) text += ' ';
+        }
+        return text.trim();
+    }
+
+    function generateRepeat(options) {
+        const keys = (options.targetKeys || []).filter(k => k && k !== 'Enter' && k !== 'Tab');
+        const unit = keys.length ? keys.join(' ') : 'a';
+        const targetLen = options.length || DEFAULT_LENGTH;
+        let text = '';
+        while (text.length < targetLen) {
+            text += `${unit} `;
+        }
+        return text.trim();
+    }
+
+    /**
+     * @param {Object} options
+     * @returns {{ text: string, stats: { length: number, targetCharRatio: number } }}
+     */
+    function generateExercise(options = {}) {
+        const length = Math.max(
+            MIN_LENGTH,
+            Math.min(MAX_LENGTH, Number(options.length) || DEFAULT_LENGTH),
+        );
+        const style = options.style || 'words';
+        const seed = Number.isFinite(options.seed) ? options.seed : Date.now();
+        const rng = style === 'repeat' ? null : createRng(seed);
+        const targetKeys = [...(options.targetKeys || [])];
+
+        let text;
+        if (style === 'random') {
+            text = generateRandom({ ...options, length }, rng);
+        } else if (style === 'repeat') {
+            text = generateRepeat({ ...options, length });
+        } else {
+            text = generateWords({ ...options, length }, rng);
+        }
+
+        if (text.length > length) {
+            text = text.slice(0, length).trim();
+        }
+
+        let attempts = 0;
+        while (attempts < 3 && targetKeys.length > 0) {
+            const ratio = countTargetChars(text, targetKeys) / Math.max(text.replace(/\s/g, '').length, 1);
+            if (ratio >= 0.25) break;
+            if (style === 'repeat') break;
+            text = style === 'random' ? generateRandom({ ...options, length }, rng) : generateWords({ ...options, length }, rng);
+            if (text.length > length) text = text.slice(0, length).trim();
+            attempts++;
+        }
+
+        const alphaLen = Math.max(text.replace(/\s/g, '').length, 1);
+        return {
+            text,
+            stats: {
+                length: text.length,
+                targetCharRatio: countTargetChars(text, targetKeys) / alphaLen,
+            },
+        };
+    }
+
+    window.ExerciseGenerator = {
+        generateExercise,
+        createRng,
+        MIN_LENGTH,
+        MAX_LENGTH,
+        DEFAULT_LENGTH,
+    };
+})();

--- a/gui/src/js/practice/exercise-generator.js
+++ b/gui/src/js/practice/exercise-generator.js
@@ -36,15 +36,30 @@
 
     /**
      * @param {string[]} targetKeys
-     * @returns {boolean}
      */
-    function wordMatches(word, targetKeys) {
-        const lower = word.toLowerCase();
-        return targetKeys.some(k => {
-            if (k === ' ') return lower.includes(' ');
-            if (k.length !== 1) return false;
-            return lower.includes(k);
-        });
+    function buildAllowedChars(targetKeys) {
+        const letters = [];
+        let allowSpace = false;
+        for (const k of targetKeys || []) {
+            if (k === ' ') {
+                allowSpace = true;
+                continue;
+            }
+            if (k.length === 1) letters.push(k.toLowerCase());
+        }
+        return { letters: [...new Set(letters)], allowSpace };
+    }
+
+    /**
+     * @param {string} word
+     * @param {Set<string>} allowed
+     */
+    function wordUsesOnlyAllowed(word, allowed) {
+        for (const ch of word.toLowerCase()) {
+            if (ch >= 'a' && ch <= 'z' && !allowed.has(ch)) return false;
+            if (ch >= '0' && ch <= '9' && !allowed.has(ch)) return false;
+        }
+        return true;
     }
 
     /**
@@ -65,8 +80,9 @@
      * @param {() => number} rng
      */
     function buildEmphasisChunk(targetKeys, rng) {
-        const key = pick(rng, targetKeys.filter(k => k !== 'Enter' && k !== 'Tab'));
-        if (!key || key === ' ') return '   ';
+        const pool = targetKeys.filter(k => k && k !== 'Enter' && k !== 'Tab' && k !== ' ');
+        const key = pick(rng, pool.length ? pool : ['a']);
+        if (!key) return '   ';
         if (key.length === 1) {
             const rep = 2 + Math.floor(rng() * 2);
             return `${key.repeat(rep)} `;
@@ -75,32 +91,83 @@
     }
 
     /**
+     * Build pseudo-words using only allowed characters.
+     * @param {{ letters: string[] }} allowed
+     * @param {() => number} rng
+     */
+    function randomChunk(allowed, rng) {
+        if (!allowed.letters.length) return '';
+        const len = 3 + Math.floor(rng() * 4);
+        let s = '';
+        for (let i = 0; i < len; i++) s += pick(rng, allowed.letters);
+        return s;
+    }
+
+    /**
+     * Words built only from the target key set (home row, numbers, etc.).
+     */
+    function generateConstrainedWords(options, rng) {
+        const { letters, allowSpace } = buildAllowedChars(options.targetKeys);
+        const allowedSet = new Set(letters);
+        const dict = window.PracticeWordlistEN || [];
+        const exclusive = dict.filter(w => w && wordUsesOnlyAllowed(w, allowedSet));
+        const pool = exclusive.length >= 8 ? exclusive : null;
+        let text = '';
+        const targetLen = options.length || DEFAULT_LENGTH;
+
+        while (text.length < targetLen) {
+            const roll = rng();
+            if (roll < 0.25) {
+                text += `${buildEmphasisChunk(options.targetKeys, rng)}`;
+            } else if (pool && roll < 0.85) {
+                text += `${pick(rng, pool)} `;
+            } else {
+                const chunk = randomChunk({ letters, allowSpace }, rng);
+                if (chunk) text += `${chunk} `;
+            }
+        }
+        return text.trim();
+    }
+
+    /**
      * @param {Object} options
-     * @param {string[]} options.targetKeys
-     * @param {number} [options.length]
-     * @param {string} [options.style] words | random | repeat
-     * @param {number} [options.seed]
+     * @param {() => number} rng
      */
     function generateWords(options, rng) {
+        const { letters } = buildAllowedChars(options.targetKeys);
+        const dict = window.PracticeWordlistEN || [];
+        const allowedSet = new Set(letters);
+
+        // Narrow groups (home row, numbers): only dictionary words using allowed letters.
+        const useConstrained =
+            letters.length > 0 &&
+            (letters.length <= 14 ||
+                dict.filter(w => wordUsesOnlyAllowed(w, allowedSet)).length < 12);
+
+        if (useConstrained) {
+            return generateConstrainedWords(options, rng);
+        }
+
         const targetKeys = options.targetKeys || [];
-        const words = window.PracticeWordlistEN || [];
-        const targetWords = words.filter(w => wordMatches(w, targetKeys));
-        const pool = targetWords.length > 0 ? targetWords : words;
+        const targetWords = dict.filter(w => {
+            const lower = w.toLowerCase();
+            return targetKeys.some(k => {
+                if (k === ' ') return lower.includes(' ');
+                if (k.length !== 1) return false;
+                return lower.includes(k);
+            });
+        });
+        const pool = targetWords.length > 0 ? targetWords : dict;
         const weighted = [];
         pool.forEach(w => {
-            const weight = wordMatches(w, targetKeys) ? 3 : 1;
+            const weight = targetWords.includes(w) ? 3 : 1;
             for (let i = 0; i < weight; i++) weighted.push(w);
         });
-        const filler = words.filter(w => !wordMatches(w, targetKeys));
         let text = '';
         while (text.length < (options.length || DEFAULT_LENGTH)) {
             const roll = rng();
-            if (roll < 0.2) {
+            if (roll < 0.35) {
                 text += buildEmphasisChunk(targetKeys, rng);
-            } else if (roll < 0.9) {
-                text += `${pick(rng, weighted)} `;
-            } else if (filler.length) {
-                text += `${pick(rng, filler)} `;
             } else {
                 text += `${pick(rng, weighted)} `;
             }
@@ -109,13 +176,17 @@
     }
 
     function generateRandom(options, rng) {
-        const keys = (options.targetKeys || []).filter(k => k && k !== 'Enter' && k !== 'Tab');
+        const keys = (options.targetKeys || []).filter(
+            k => k && k !== 'Enter' && k !== 'Tab' && k !== 'CapsLock',
+        );
         const chars = keys.length ? keys : ['a'];
         let text = '';
         while (text.length < (options.length || DEFAULT_LENGTH)) {
             const key = pick(rng, chars);
-            text += key === ' ' ? ' ' : key.length === 1 ? key : `${key} `;
-            if (rng() < 0.14) text += ' ';
+            if (key === ' ') text += ' ';
+            else if (key.length === 1) text += key;
+            else text += `${key} `;
+            if (rng() < 0.12) text += ' ';
         }
         return text.trim();
     }
@@ -159,11 +230,17 @@
         }
 
         let attempts = 0;
-        while (attempts < 3 && targetKeys.length > 0) {
-            const ratio = countTargetChars(text, targetKeys) / Math.max(text.replace(/\s/g, '').length, 1);
-            if (ratio >= 0.25) break;
+        const minRatio = style === 'random' || style === 'repeat' ? 0.85 : 0.55;
+        while (attempts < 4 && targetKeys.length > 0) {
+            const alphaLen = Math.max(text.replace(/\s/g, '').length, 1);
+            const ratio = countTargetChars(text, targetKeys) / alphaLen;
+            if (ratio >= minRatio) break;
             if (style === 'repeat') break;
-            text = style === 'random' ? generateRandom({ ...options, length }, rng) : generateWords({ ...options, length }, rng);
+            if (style === 'random') {
+                text = generateRandom({ ...options, length }, rng);
+            } else {
+                text = generateConstrainedWords({ ...options, length }, rng);
+            }
             if (text.length > length) text = text.slice(0, length).trim();
             attempts++;
         }
@@ -181,6 +258,8 @@
     window.ExerciseGenerator = {
         generateExercise,
         createRng,
+        buildAllowedChars,
+        wordUsesOnlyAllowed,
         MIN_LENGTH,
         MAX_LENGTH,
         DEFAULT_LENGTH,

--- a/gui/src/js/practice/practice-manager.js
+++ b/gui/src/js/practice/practice-manager.js
@@ -115,6 +115,7 @@
         });
         updateBanner();
         window.ModalManager?.hide();
+        document.getElementById('text-input')?.focus();
     }
 
     /**
@@ -141,6 +142,7 @@
         });
         updateBanner();
         window.ModalManager?.hide();
+        document.getElementById('text-input')?.focus();
     }
 
     function regenerateTargeted() {

--- a/gui/src/js/practice/practice-manager.js
+++ b/gui/src/js/practice/practice-manager.js
@@ -1,0 +1,206 @@
+// Copyright 2025 Asher Buk
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/AshBuk/FingerGo
+
+/**
+ * Coordinates targeted and custom-text practice flows.
+ */
+(() => {
+    const esc = window.AppUtils?.escapeHtml || (s => String(s ?? ''));
+
+    let activeMeta = null;
+    let lastExerciseOptions = null;
+
+    function getLayoutId() {
+        return window.SettingsManager?.getKeyboardLayout?.() || 'en-qwerty';
+    }
+
+    function setBannerVisible(visible, html = '') {
+        const banner = document.getElementById('practice-banner');
+        if (!banner) return;
+        banner.hidden = !visible;
+        if (visible && html) banner.innerHTML = html;
+    }
+
+    function updateBanner() {
+        if (!activeMeta) {
+            setBannerVisible(false);
+            return;
+        }
+        const modeLabel =
+            activeMeta.practiceMode === 'custom-text' ? 'Custom text' : 'Targeted practice';
+        const keys =
+            activeMeta.targetKeys?.length > 0
+                ? esc(activeMeta.targetKeys.slice(0, 12).join(' ')) +
+                  (activeMeta.targetKeys.length > 12 ? '…' : '')
+                : '';
+        setBannerVisible(
+            true,
+            `<span class="practice-banner-label">${esc(modeLabel)}</span>` +
+                `<span class="practice-banner-detail">${esc(activeMeta.practiceGroupName || '')}</span>` +
+                (keys ? `<span class="practice-banner-keys">${keys}</span>` : '') +
+                `<button type="button" id="practice-exit-btn" class="practice-banner-btn">Exit</button>` +
+                (activeMeta.practiceMode === 'targeted'
+                    ? `<button type="button" id="practice-change-btn" class="practice-banner-btn">Change</button>`
+                    : ''),
+        );
+        document.getElementById('practice-exit-btn')?.addEventListener('click', () => exitPractice());
+        document.getElementById('practice-change-btn')?.addEventListener('click', () => openTargetedModal());
+    }
+
+    async function fetchCustomGroups() {
+        if (!window.go?.app?.App?.GetPracticeGroups) return [];
+        try {
+            return (await window.go.app.App.GetPracticeGroups()) || [];
+        } catch (err) {
+            console.error('GetPracticeGroups failed:', err);
+            return [];
+        }
+    }
+
+    async function fetchWeakKeys(limit = 50) {
+        if (!window.go?.app?.App?.AggregateKeyMistakes) return [];
+        try {
+            const agg = await window.go.app.App.AggregateKeyMistakes(limit);
+            return Object.entries(agg || {})
+                .filter(([, count]) => count > 0)
+                .sort((a, b) => b[1] - a[1])
+                .slice(0, 8);
+        } catch (err) {
+            console.error('AggregateKeyMistakes failed:', err);
+            return [];
+        }
+    }
+
+    async function saveCustomGroup(group) {
+        return window.go.app.App.SavePracticeGroup(group);
+    }
+
+    async function deleteCustomGroup(id) {
+        return window.go.app.App.DeletePracticeGroup(id);
+    }
+
+    /**
+     * @param {{ id: string, name: string, keys: string[], source?: string }} group
+     * @param {{ length?: number, style?: string, seed?: number }} options
+     */
+    function startTargeted(group, options = {}) {
+        if (!group?.keys?.length) {
+            console.error('PracticeManager: group has no keys');
+            return;
+        }
+        const exerciseOptions = {
+            targetKeys: group.keys,
+            length: options.length || window.ExerciseGenerator?.DEFAULT_LENGTH || 300,
+            style: options.style || 'words',
+            seed: options.seed,
+        };
+        const result = window.ExerciseGenerator?.generateExercise(exerciseOptions);
+        if (!result?.text) return;
+
+        lastExerciseOptions = { group, options: exerciseOptions };
+        activeMeta = {
+            practiceMode: 'targeted',
+            practiceGroupId: group.id || '',
+            practiceGroupName: group.name || 'Targeted',
+            targetKeys: [...group.keys],
+            textTitle: group.name || 'Targeted Practice',
+        };
+
+        window.SessionManager?.loadEphemeralText?.(result.text, {
+            textId: '',
+            textTitle: activeMeta.textTitle,
+            categoryId: '',
+            ...activeMeta,
+        });
+        updateBanner();
+        window.ModalManager?.hide();
+    }
+
+    /**
+     * @param {string} text
+     */
+    function startCustomText(text) {
+        const trimmed = (text || '').trim();
+        if (!trimmed) return;
+        lastExerciseOptions = null;
+        const title =
+            trimmed.split('\n')[0].trim().slice(0, 64) || 'Custom text practice';
+        activeMeta = {
+            practiceMode: 'custom-text',
+            practiceGroupId: '',
+            practiceGroupName: title,
+            targetKeys: [],
+            textTitle: title,
+        };
+        window.SessionManager?.loadEphemeralText?.(trimmed, {
+            textId: '',
+            textTitle: title,
+            categoryId: '',
+            ...activeMeta,
+        });
+        updateBanner();
+        window.ModalManager?.hide();
+    }
+
+    function regenerateTargeted() {
+        if (!lastExerciseOptions) return false;
+        const { group, options } = lastExerciseOptions;
+        startTargeted(group, { ...options, seed: Date.now() });
+        return true;
+    }
+
+    function clearState() {
+        activeMeta = null;
+        lastExerciseOptions = null;
+        setBannerVisible(false);
+    }
+
+    function exitPractice() {
+        clearState();
+        window.SessionManager?.restoreLibraryText?.();
+    }
+
+    function openTargetedModal() {
+        window.UIManager?.showModal('targeted-practice', {});
+    }
+
+    function openCustomTextModal() {
+        window.UIManager?.showModal('custom-text-practice', {});
+    }
+
+    function getMeta() {
+        return activeMeta ? { ...activeMeta } : null;
+    }
+
+    function isActive() {
+        return activeMeta !== null;
+    }
+
+    function init() {
+        window.EventBus?.on('typing:complete', () => {
+            if (activeMeta) updateBanner();
+        });
+    }
+
+    window.PracticeManager = {
+        init,
+        openTargetedModal,
+        openCustomTextModal,
+        startTargeted,
+        startCustomText,
+        exitPractice,
+        clearState,
+        regenerateTargeted,
+        getMeta,
+        isActive,
+        fetchCustomGroups,
+        fetchWeakKeys,
+        saveCustomGroup,
+        deleteCustomGroup,
+        getBuiltinGroups: () =>
+            window.BuiltinPracticeGroups?.getBuiltinGroups?.(getLayoutId()) || [],
+        getLayoutId,
+        esc,
+    };
+})();

--- a/gui/src/js/practice/wordlist-en.js
+++ b/gui/src/js/practice/wordlist-en.js
@@ -1,0 +1,30 @@
+// Copyright 2025 Asher Buk
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/AshBuk/FingerGo
+
+/**
+ * Common English words for targeted practice generation.
+ */
+(() => {
+    window.PracticeWordlistEN = [
+        'the', 'be', 'to', 'of', 'and', 'a', 'in', 'that', 'have', 'it',
+        'for', 'not', 'on', 'with', 'he', 'as', 'you', 'do', 'at', 'this',
+        'but', 'his', 'by', 'from', 'they', 'we', 'say', 'her', 'she', 'or',
+        'an', 'will', 'my', 'one', 'all', 'would', 'there', 'their', 'what',
+        'so', 'up', 'out', 'if', 'about', 'who', 'get', 'which', 'go', 'me',
+        'when', 'make', 'can', 'like', 'time', 'no', 'just', 'him', 'know',
+        'take', 'people', 'into', 'year', 'your', 'good', 'some', 'could',
+        'them', 'see', 'other', 'than', 'then', 'now', 'look', 'only', 'come',
+        'its', 'over', 'think', 'also', 'back', 'after', 'use', 'two', 'how',
+        'our', 'work', 'first', 'well', 'way', 'even', 'new', 'want', 'because',
+        'any', 'these', 'give', 'day', 'most', 'us', 'quick', 'brown', 'fox',
+        'jumps', 'lazy', 'dog', 'type', 'fast', 'keys', 'practice', 'finger',
+        'keyboard', 'letter', 'word', 'line', 'space', 'home', 'row', 'left',
+        'right', 'hand', 'train', 'skill', 'speed', 'accuracy', 'lesson',
+        'repeat', 'focus', 'learn', 'code', 'text', 'write', 'read', 'keep',
+        'start', 'stop', 'help', 'need', 'find', 'play', 'run', 'move', 'turn',
+        'open', 'close', 'hold', 'press', 'shift', 'enter', 'tab', 'copy',
+        'paste', 'save', 'load', 'file', 'path', 'name', 'value', 'data',
+        'list', 'map', 'set', 'key', 'test', 'pass', 'fail', 'true', 'false',
+    ];
+})();

--- a/gui/src/js/session.js
+++ b/gui/src/js/session.js
@@ -11,6 +11,8 @@
     let currentText = null;
     let currentTextMeta = null;
     let startHandlerRef = null;
+    /** @type {{ text: string, meta: object }|null} */
+    let librarySnapshot = null;
 
     /**
      * Set keyboard target to first character of text
@@ -33,6 +35,7 @@
             return null;
         }
         const metrics = window.TypingEngine.getMetrics();
+        const practice = getPracticeMeta();
         return {
             ...session,
             wpm: metrics?.wpm ?? 0,
@@ -41,6 +44,7 @@
             duration: metrics?.time ?? session.duration ?? 0,
             totalErrors: session.totalErrors ?? 0,
             totalKeystrokes: session.totalKeystrokes ?? 0,
+            ...(practice || {}),
         };
     }
 
@@ -91,7 +95,74 @@
      * @param {string} textId
      * @returns {Promise<string|undefined>} Text content or undefined on failure
      */
+    function clearEphemeralState() {
+        librarySnapshot = null;
+    }
+
+    /**
+     * Load ephemeral practice text without changing lastTextId.
+     * @param {string} text
+     * @param {Object} meta
+     */
+    function loadEphemeralText(text, meta) {
+        if (!librarySnapshot && currentText != null) {
+            librarySnapshot = {
+                text: currentText,
+                meta: currentTextMeta ? { ...currentTextMeta } : null,
+            };
+        }
+        window.TypingEngine?.reset();
+        currentText = text;
+        currentTextMeta = meta ? { ...meta } : null;
+        window.UIManager?.renderText(currentText);
+        setInitialTarget(currentText);
+        setupTypingStart();
+    }
+
+    /**
+     * Restore library text after ephemeral practice.
+     */
+    async function restoreLibraryText() {
+        window.TypingEngine?.reset();
+        window.StatsManager?.clearHeatmap();
+        if (librarySnapshot?.text) {
+            currentText = librarySnapshot.text;
+            currentTextMeta = librarySnapshot.meta ? { ...librarySnapshot.meta } : null;
+            librarySnapshot = null;
+            window.UIManager?.renderText(currentText);
+            setInitialTarget(currentText);
+            setupTypingStart();
+            return;
+        }
+        librarySnapshot = null;
+        const settings = await window.SettingsManager?.load?.();
+        if (settings?.lastTextId) {
+            await loadText(settings.lastTextId);
+            return;
+        }
+        await loadDefault();
+    }
+
+    /**
+     * @returns {Object|null}
+     */
+    function getPracticeMeta() {
+        const meta = window.PracticeManager?.getMeta?.();
+        if (meta) return { ...meta };
+        if (currentTextMeta?.practiceMode) {
+            return {
+                practiceMode: currentTextMeta.practiceMode,
+                practiceGroupId: currentTextMeta.practiceGroupId || '',
+                practiceGroupName: currentTextMeta.practiceGroupName || '',
+                targetKeys: currentTextMeta.targetKeys || [],
+            };
+        }
+        return null;
+    }
+
     async function loadText(textId) {
+        window.PracticeManager?.clearState?.();
+        clearEphemeralState();
         if (!window.go?.app?.App?.Text) {
             console.error('Internal layer not available');
             return;
@@ -175,6 +246,9 @@
         window.UIManager?.updateStats(0, 0, 100, 0);
         window.StatsManager?.clearHeatmap();
         window.KeyboardUI?.clearAllErrors();
+        if (window.PracticeManager?.isActive?.() && window.PracticeManager?.regenerateTargeted?.()) {
+            return;
+        }
         // Rerender current text or load default
         if (currentText?.length) {
             window.UIManager?.renderText(currentText);
@@ -210,15 +284,26 @@
      * @returns {{textId: string, textTitle: string, categoryId: string}|null}
      */
     function getTextMeta() {
-        return currentTextMeta ? { ...currentTextMeta } : null;
+        const base = currentTextMeta ? { ...currentTextMeta } : null;
+        const practice = getPracticeMeta();
+        if (!practice) return base;
+        return { ...(base || {}), ...practice };
+    }
+
+    function isEphemeral() {
+        return librarySnapshot !== null || Boolean(currentTextMeta?.practiceMode);
     }
 
     // Export API
     window.SessionManager = {
         loadDefault,
         loadText,
+        loadEphemeralText,
+        restoreLibraryText,
         reset,
         getTextMeta,
+        getPracticeMeta,
+        isEphemeral,
         showStatsModal,
         setupTypingStart,
     };

--- a/gui/src/js/shortcuts.js
+++ b/gui/src/js/shortcuts.js
@@ -67,6 +67,12 @@
                 window.SettingsManager?.toggleZenMode();
                 return;
             }
+            // Ctrl+Alt+P - Targeted practice
+            if (e.key === 'p' && (e.ctrlKey || e.metaKey) && e.altKey) {
+                e.preventDefault();
+                window.PracticeManager?.openTargetedModal();
+                return;
+            }
             // Ctrl+Alt+R - Reset session
             if (e.key === 'r' && (e.ctrlKey || e.metaKey) && e.altKey) {
                 e.preventDefault();

--- a/gui/src/js/stats.js
+++ b/gui/src/js/stats.js
@@ -28,11 +28,16 @@
             if (window.go?.app?.App?.SaveSession) {
                 // Build payload matching SessionPayload struct
                 const textMeta = window.App?.getTextMeta?.() || {};
+                const practice = window.SessionManager?.getPracticeMeta?.() || {};
                 const payload = {
                     text: sessionData.text || '',
                     textId: textMeta.textId || '',
                     textTitle: textMeta.textTitle || '',
                     categoryId: textMeta.categoryId || '',
+                    practiceMode: practice.practiceMode || '',
+                    practiceGroupId: practice.practiceGroupId || '',
+                    practiceGroupName: practice.practiceGroupName || '',
+                    targetKeys: practice.targetKeys || [],
                     mistakes: sessionData.mistakes || {},
                     wpm: sessionData.wpm || 0,
                     cpm: sessionData.cpm || 0,

--- a/gui/src/js/ui.js
+++ b/gui/src/js/ui.js
@@ -337,6 +337,8 @@
         }
         // Show summary modal
         data.isCompleted = true; // Session completed
+        const practice = window.SessionManager?.getPracticeMeta?.();
+        if (practice) Object.assign(data, practice);
         showModal('session-summary', data);
     });
 

--- a/gui/src/styles/practice.css
+++ b/gui/src/styles/practice.css
@@ -1,0 +1,246 @@
+/* Targeted and custom text practice UI */
+
+#practice-banner {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem 1rem;
+    padding: 0.35rem 0.75rem;
+    margin: 0 0 0.5rem;
+    font-size: 0.85rem;
+    border-radius: 6px;
+    background: var(--surface-elevated, rgba(255, 255, 255, 0.06));
+    border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.1));
+}
+
+#practice-banner[hidden] {
+    display: none;
+}
+
+.practice-banner-label {
+    font-weight: 600;
+}
+
+.practice-banner-detail {
+    opacity: 0.85;
+}
+
+.practice-banner-keys {
+    font-family: monospace;
+    font-size: 0.8rem;
+    opacity: 0.75;
+}
+
+.practice-banner-btn {
+    margin-left: auto;
+    padding: 0.15rem 0.5rem;
+    font-size: 0.8rem;
+    cursor: pointer;
+    border-radius: 4px;
+    border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.15));
+    background: transparent;
+    color: inherit;
+}
+
+.practice-section {
+    margin-bottom: 1.25rem;
+}
+
+.practice-section h4 {
+    margin: 0 0 0.5rem;
+    font-size: 0.95rem;
+}
+
+.practice-muted {
+    margin: 0;
+    font-size: 0.85rem;
+    opacity: 0.7;
+}
+
+.practice-group-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.practice-group-card {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    min-width: 8rem;
+    max-width: 14rem;
+    padding: 0.5rem 0.65rem;
+    text-align: left;
+    cursor: pointer;
+    border-radius: 6px;
+    border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.12));
+    background: var(--surface-elevated, rgba(255, 255, 255, 0.04));
+    color: inherit;
+}
+
+.practice-group-edit {
+    position: absolute;
+    top: 0.25rem;
+    right: 0.25rem;
+    padding: 0.1rem 0.25rem;
+    font-size: 0.75rem;
+    border: none;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    opacity: 0.7;
+}
+
+.practice-group-card.selected {
+    border-color: var(--accent, #4a90e2);
+    box-shadow: 0 0 0 1px var(--accent, #4a90e2);
+}
+
+.practice-group-name {
+    font-weight: 600;
+    font-size: 0.9rem;
+}
+
+.practice-group-keys {
+    font-size: 0.75rem;
+    font-family: monospace;
+    opacity: 0.75;
+    margin-top: 0.25rem;
+}
+
+.weak-keys-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.weak-key-chip {
+    padding: 0.15rem 0.45rem;
+    border-radius: 4px;
+    font-size: 0.8rem;
+    background: rgba(244, 67, 54, 0.15);
+}
+
+.weak-key-chip em {
+    font-style: normal;
+    opacity: 0.8;
+}
+
+.practice-link-btn {
+    padding: 0;
+    border: none;
+    background: none;
+    color: var(--accent, #4a90e2);
+    cursor: pointer;
+    font-size: 0.85rem;
+    text-decoration: underline;
+}
+
+.practice-options {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    align-items: center;
+    margin-bottom: 0.5rem;
+}
+
+.practice-preview {
+    font-family: monospace;
+    font-size: 0.85rem;
+    line-height: 1.5;
+    margin: 0;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.practice-preview-box {
+    max-height: 6rem;
+    overflow: auto;
+    padding: 0.5rem;
+    border-radius: 4px;
+    background: var(--surface-elevated, rgba(0, 0, 0, 0.2));
+}
+
+.practice-modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    margin-top: 1rem;
+}
+
+.practice-modal-actions button {
+    padding: 0.4rem 0.9rem;
+    cursor: pointer;
+}
+
+#custom-practice-input {
+    width: 100%;
+    box-sizing: border-box;
+    margin-bottom: 0.5rem;
+    font-family: inherit;
+}
+
+.practice-editor label {
+    display: block;
+    margin-bottom: 0.5rem;
+}
+
+.practice-editor input[type='text'] {
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.key-picker-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    max-height: 8rem;
+    overflow: auto;
+    margin: 0.5rem 0;
+}
+
+.key-pick-btn {
+    padding: 0.2rem 0.35rem;
+    font-size: 0.75rem;
+    font-family: monospace;
+    cursor: pointer;
+    border-radius: 3px;
+    border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.12));
+    background: transparent;
+    color: inherit;
+}
+
+.key-pick-btn.active {
+    background: var(--accent, #4a90e2);
+    border-color: var(--accent, #4a90e2);
+    color: #fff;
+}
+
+.practice-editor-actions {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: flex-end;
+}
+
+.summary-practice {
+    margin-bottom: 1rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.1));
+}
+
+.summary-practice h4 {
+    margin: 0 0 0.25rem;
+}
+
+.practice-summary-mode,
+.practice-summary-keys {
+    margin: 0.15rem 0;
+    font-size: 0.85rem;
+    opacity: 0.85;
+}
+
+body.zen-mode #practice-banner .practice-banner-btn:not(#practice-exit-btn) {
+    display: none;
+}

--- a/internal/domain/practice.go
+++ b/internal/domain/practice.go
@@ -1,0 +1,36 @@
+// Copyright 2025 Asher Buk
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/AshBuk/FingerGo
+
+package domain
+
+import "time"
+
+const (
+	PracticeModeTargeted   = "targeted"
+	PracticeModeCustomText = "custom-text"
+)
+
+// PracticeGroup is a user-defined set of keys to drill.
+type PracticeGroup struct {
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	LayoutID  string    `json:"layoutId"`
+	Keys      []string  `json:"keys"`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+// PracticeGroupStore is the on-disk envelope for custom practice groups.
+type PracticeGroupStore struct {
+	Version int             `json:"version"`
+	Groups  []PracticeGroup `json:"groups"`
+}
+
+// PracticeSessionMeta tags ephemeral or targeted practice sessions.
+type PracticeSessionMeta struct {
+	PracticeMode      string   `json:"practiceMode,omitempty"`
+	PracticeGroupID   string   `json:"practiceGroupId,omitempty"`
+	PracticeGroupName string   `json:"practiceGroupName,omitempty"`
+	TargetKeys        []string `json:"targetKeys,omitempty"`
+}

--- a/internal/domain/session.go
+++ b/internal/domain/session.go
@@ -65,7 +65,7 @@ type SessionPayload struct {
 	TotalErrors     int `json:"totalErrors"`
 	TotalKeystrokes int `json:"totalKeystrokes"`
 
-	*PracticeSessionMeta
+	PracticeSessionMeta
 }
 
 // ToTypingSession converts the payload to a normalized TypingSession.
@@ -122,13 +122,12 @@ func (p *SessionPayload) ToTypingSession(fallback time.Time) TypingSession {
 		CharacterCount:  charCount,
 		Mistakes:        mistakes,
 	}
-	if p.PracticeSessionMeta != nil {
-		session.PracticeSessionMeta = &PracticeSessionMeta{
-			PracticeMode:      strings.TrimSpace(p.PracticeMode),
-			PracticeGroupID:   strings.TrimSpace(p.PracticeGroupID),
-			PracticeGroupName: strings.TrimSpace(p.PracticeGroupName),
-			TargetKeys:        cloneTargetKeys(p.TargetKeys),
-		}
+	mode := strings.TrimSpace(p.PracticeMode)
+	if mode != "" || len(p.TargetKeys) > 0 || strings.TrimSpace(p.PracticeGroupID) != "" {
+		session.PracticeMode = mode
+		session.PracticeGroupID = strings.TrimSpace(p.PracticeGroupID)
+		session.PracticeGroupName = strings.TrimSpace(p.PracticeGroupName)
+		session.TargetKeys = cloneTargetKeys(p.TargetKeys)
 	}
 	return session
 }

--- a/internal/domain/session.go
+++ b/internal/domain/session.go
@@ -33,6 +33,11 @@ type TypingSession struct {
 	TotalKeystrokes int `json:"totalKeystrokes"`
 	TotalErrors     int `json:"totalErrors"`
 	CharacterCount  int `json:"characterCount"`
+
+	PracticeMode      string   `json:"practiceMode,omitempty"`
+	PracticeGroupID   string   `json:"practiceGroupId,omitempty"`
+	PracticeGroupName string   `json:"practiceGroupName,omitempty"`
+	TargetKeys        []string `json:"targetKeys,omitempty"`
 }
 
 // SessionTextMeta aggregates textual metadata provided by the GUI payload.
@@ -59,6 +64,8 @@ type SessionPayload struct {
 
 	TotalErrors     int `json:"totalErrors"`
 	TotalKeystrokes int `json:"totalKeystrokes"`
+
+	*PracticeSessionMeta
 }
 
 // ToTypingSession converts the payload to a normalized TypingSession.
@@ -99,7 +106,7 @@ func (p *SessionPayload) ToTypingSession(fallback time.Time) TypingSession {
 	accuracy := clamp(p.Accuracy, 0, 100)
 	totalKeystrokes := max(0, p.TotalKeystrokes)
 	totalErrors := clamp(p.TotalErrors, 0, totalKeystrokes)
-	return TypingSession{
+	session := TypingSession{
 		TextID:          strings.TrimSpace(rawTextID),
 		TextTitle:       title,
 		TextPreview:     preview,
@@ -115,6 +122,33 @@ func (p *SessionPayload) ToTypingSession(fallback time.Time) TypingSession {
 		CharacterCount:  charCount,
 		Mistakes:        mistakes,
 	}
+	if p.PracticeSessionMeta != nil {
+		session.PracticeSessionMeta = &PracticeSessionMeta{
+			PracticeMode:      strings.TrimSpace(p.PracticeMode),
+			PracticeGroupID:   strings.TrimSpace(p.PracticeGroupID),
+			PracticeGroupName: strings.TrimSpace(p.PracticeGroupName),
+			TargetKeys:        cloneTargetKeys(p.TargetKeys),
+		}
+	}
+	return session
+}
+
+func cloneTargetKeys(src []string) []string {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(src))
+	for _, k := range src {
+		k = strings.TrimSpace(k)
+		if k == "" {
+			continue
+		}
+		out = append(out, k)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func fromMillis(ms int64, fallback time.Time) time.Time {

--- a/internal/domain/session_test.go
+++ b/internal/domain/session_test.go
@@ -139,6 +139,30 @@ func TestSessionPayload_ToTypingSession(t *testing.T) {
 		}
 	})
 
+	t.Run("copies practice metadata", func(t *testing.T) {
+		payload := &SessionPayload{
+			SessionTextMeta: &SessionTextMeta{Text: "qqq aaa"},
+			PracticeSessionMeta: PracticeSessionMeta{
+				PracticeMode:      PracticeModeTargeted,
+				PracticeGroupID:   "builtin-home-row",
+				PracticeGroupName: "Home row",
+				TargetKeys:        []string{"a", "s", "d"},
+			},
+		}
+
+		session := payload.ToTypingSession(fallback)
+
+		if session.PracticeMode != PracticeModeTargeted {
+			t.Errorf("practiceMode = %q", session.PracticeMode)
+		}
+		if session.PracticeGroupID != "builtin-home-row" {
+			t.Errorf("practiceGroupId = %q", session.PracticeGroupID)
+		}
+		if len(session.TargetKeys) != 3 {
+			t.Errorf("targetKeys = %v", session.TargetKeys)
+		}
+	})
+
 	t.Run("clones mistakes map", func(t *testing.T) {
 		original := map[string]int{"a": 3, "s": 5}
 		payload := &SessionPayload{

--- a/internal/storage/practice_groups.go
+++ b/internal/storage/practice_groups.go
@@ -1,0 +1,288 @@
+// Copyright 2025 Asher Buk
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/AshBuk/FingerGo
+
+package storage
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/google/uuid"
+
+	domain "github.com/AshBuk/FingerGo/internal/domain"
+)
+
+const (
+	practiceGroupsVersion = 1
+	maxPracticeGroups    = 20
+	maxKeysPerGroup      = 30
+	maxPracticeGroupName = 64
+)
+
+// Practice group validation errors.
+var (
+	ErrPracticeGroupNotFound = errors.New("storage: practice group not found")
+	ErrPracticeGroupExists   = errors.New("storage: practice group already exists")
+	ErrTooManyPracticeGroups = errors.New("storage: too many practice groups")
+	ErrEmptyPracticeGroupName = errors.New("storage: practice group name is empty")
+	ErrPracticeGroupNameTooLong = errors.New("storage: practice group name too long")
+	ErrEmptyPracticeKeys     = errors.New("storage: practice group keys are empty")
+	ErrTooManyPracticeKeys   = errors.New("storage: too many keys in practice group")
+	ErrInvalidPracticeKey    = errors.New("storage: invalid practice key")
+)
+
+// PracticeGroupRepository persists custom practice groups.
+type PracticeGroupRepository struct {
+	storage *Manager
+	store   domain.PracticeGroupStore
+	loaded  bool
+}
+
+// NewPracticeGroupRepository wires the repository to the storage manager.
+func NewPracticeGroupRepository(mgr *Manager) (*PracticeGroupRepository, error) {
+	if mgr == nil {
+		return nil, errNilManager
+	}
+	return &PracticeGroupRepository{storage: mgr}, nil
+}
+
+// List returns all custom practice groups.
+func (r *PracticeGroupRepository) List() ([]domain.PracticeGroup, error) {
+	if err := r.ensureLoaded(); err != nil {
+		return nil, err
+	}
+	out := make([]domain.PracticeGroup, len(r.store.Groups))
+	copy(out, r.store.Groups)
+	return out, nil
+}
+
+// Save creates or updates a practice group.
+func (r *PracticeGroupRepository) Save(group *domain.PracticeGroup) (domain.PracticeGroup, error) {
+	if err := r.ensureLoaded(); err != nil {
+		return domain.PracticeGroup{}, err
+	}
+	if group == nil {
+		return domain.PracticeGroup{}, ErrEmptyPracticeGroupName
+	}
+	normalized, err := validatePracticeGroup(*group)
+	if err != nil {
+		return domain.PracticeGroup{}, err
+	}
+	now := time.Now().UTC()
+	if normalized.ID == "" {
+		normalized.ID = uuid.NewString()
+		normalized.CreatedAt = now
+		if len(r.store.Groups) >= maxPracticeGroups {
+			return domain.PracticeGroup{}, ErrTooManyPracticeGroups
+		}
+		normalized.UpdatedAt = now
+		r.store.Groups = append(r.store.Groups, normalized)
+	} else {
+		if err := validateTextID(normalized.ID); err != nil {
+			return domain.PracticeGroup{}, err
+		}
+		idx := -1
+		for i, g := range r.store.Groups {
+			if g.ID == normalized.ID {
+				idx = i
+				break
+			}
+		}
+		if idx < 0 {
+			return domain.PracticeGroup{}, ErrPracticeGroupNotFound
+		}
+		normalized.CreatedAt = r.store.Groups[idx].CreatedAt
+		if normalized.CreatedAt.IsZero() {
+			normalized.CreatedAt = now
+		}
+		normalized.UpdatedAt = now
+		r.store.Groups[idx] = normalized
+	}
+	if err := r.persist(); err != nil {
+		return domain.PracticeGroup{}, err
+	}
+	return normalized, nil
+}
+
+// Delete removes a practice group by ID.
+func (r *PracticeGroupRepository) Delete(id string) error {
+	if err := validateTextID(id); err != nil {
+		return err
+	}
+	if err := r.ensureLoaded(); err != nil {
+		return err
+	}
+	idx := -1
+	for i, g := range r.store.Groups {
+		if g.ID == id {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return ErrPracticeGroupNotFound
+	}
+	r.store.Groups = append(r.store.Groups[:idx], r.store.Groups[idx+1:]...)
+	return r.persist()
+}
+
+func validatePracticeGroup(group domain.PracticeGroup) (domain.PracticeGroup, error) {
+	name := strings.TrimSpace(group.Name)
+	if name == "" {
+		return domain.PracticeGroup{}, ErrEmptyPracticeGroupName
+	}
+	if utf8.RuneCountInString(name) > maxPracticeGroupName {
+		return domain.PracticeGroup{}, ErrPracticeGroupNameTooLong
+	}
+	layoutID := strings.TrimSpace(group.LayoutID)
+	if layoutID == "" {
+		layoutID = "en-qwerty"
+	}
+	if err := validateTextID(layoutID); err != nil {
+		return domain.PracticeGroup{}, fmt.Errorf("%w: invalid layout id", ErrInvalidPracticeKey)
+	}
+	keys, err := normalizePracticeKeys(group.Keys)
+	if err != nil {
+		return domain.PracticeGroup{}, err
+	}
+	return domain.PracticeGroup{
+		ID:       strings.TrimSpace(group.ID),
+		Name:     name,
+		LayoutID: layoutID,
+		Keys:     keys,
+	}, nil
+}
+
+func normalizePracticeKeys(keys []string) ([]string, error) {
+	if len(keys) == 0 {
+		return nil, ErrEmptyPracticeKeys
+	}
+	if len(keys) > maxKeysPerGroup {
+		return nil, ErrTooManyPracticeKeys
+	}
+	seen := make(map[string]struct{}, len(keys))
+	out := make([]string, 0, len(keys))
+	for _, raw := range keys {
+		k := strings.TrimSpace(raw)
+		if k == "" {
+			continue
+		}
+		if err := validatePracticeKey(k); err != nil {
+			return nil, err
+		}
+		if _, dup := seen[k]; dup {
+			continue
+		}
+		seen[k] = struct{}{}
+		out = append(out, k)
+	}
+	if len(out) == 0 {
+		return nil, ErrEmptyPracticeKeys
+	}
+	return out, nil
+}
+
+func validatePracticeKey(key string) error {
+	if key == " " {
+		return nil
+	}
+	if len(key) > 12 {
+		return fmt.Errorf("%w: %q", ErrInvalidPracticeKey, key)
+	}
+	disallowed := map[string]struct{}{
+		"Tab": {}, "CapsLock": {}, "Shift": {}, "Control": {}, "Alt": {},
+		"Meta": {}, "Backspace": {}, "Enter": {},
+	}
+	if _, ok := disallowed[key]; ok {
+		return fmt.Errorf("%w: %q", ErrInvalidPracticeKey, key)
+	}
+	if utf8.RuneCountInString(key) == 1 {
+		return nil
+	}
+	allowed := map[string]struct{}{
+		"Space": {},
+	}
+	if _, ok := allowed[key]; ok {
+		return nil
+	}
+	return fmt.Errorf("%w: %q", ErrInvalidPracticeKey, key)
+}
+
+func (r *PracticeGroupRepository) ensureLoaded() error {
+	if r.loaded {
+		return nil
+	}
+	path := r.storage.join(practiceGroupsFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			r.store = domain.PracticeGroupStore{Version: practiceGroupsVersion, Groups: nil}
+			r.loaded = true
+			return nil
+		}
+		return fmt.Errorf("storage: read practice groups %q: %w", path, err)
+	}
+	clean := bytes.TrimSpace(data)
+	if len(clean) == 0 {
+		r.store = domain.PracticeGroupStore{Version: practiceGroupsVersion, Groups: nil}
+	} else {
+		var store domain.PracticeGroupStore
+		if err := json.Unmarshal(clean, &store); err != nil {
+			return fmt.Errorf("storage: parse practice groups %q: %w", path, err)
+		}
+		if store.Version == 0 {
+			store.Version = practiceGroupsVersion
+		}
+		r.store = store
+	}
+	r.loaded = true
+	return nil
+}
+
+func (r *PracticeGroupRepository) persist() error {
+	r.store.Version = practiceGroupsVersion
+	path := r.storage.join(practiceGroupsFile)
+	data, err := json.MarshalIndent(r.store, "", "  ")
+	if err != nil {
+		return fmt.Errorf("storage: marshal practice groups: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("storage: write practice groups %q: %w", path, err)
+	}
+	return nil
+}
+
+// AggregateKeyMistakes sums mistake counts from the most recent sessions.
+func (r *SessionRepository) AggregateKeyMistakes(limit int) (map[string]int, error) {
+	if err := r.ensureLoaded(); err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		limit = 50
+	}
+	total := len(r.sessions)
+	if total == 0 {
+		return map[string]int{}, nil
+	}
+	start := total - limit
+	if start < 0 {
+		start = 0
+	}
+	agg := make(map[string]int)
+	for i := start; i < total; i++ {
+		for key, count := range r.sessions[i].Mistakes {
+			if count <= 0 {
+				continue
+			}
+			agg[key] += count
+		}
+	}
+	return agg, nil
+}

--- a/internal/storage/practice_groups_test.go
+++ b/internal/storage/practice_groups_test.go
@@ -1,0 +1,102 @@
+// Copyright 2025 Asher Buk
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/AshBuk/FingerGo
+
+package storage
+
+import (
+	"testing"
+
+	domain "github.com/AshBuk/FingerGo/internal/domain"
+)
+
+func TestPracticeGroupRepository_CRUD(t *testing.T) {
+	mgr, err := New(t.TempDir())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := mgr.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	repo, err := NewPracticeGroupRepository(mgr)
+	if err != nil {
+		t.Fatalf("NewPracticeGroupRepository: %v", err)
+	}
+
+	saved, err := repo.Save(&domain.PracticeGroup{
+		Name:     "Weak keys",
+		LayoutID: "en-qwerty",
+		Keys:     []string{"q", "p", ";"},
+	})
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if saved.ID == "" {
+		t.Fatal("expected generated id")
+	}
+
+	groups, err := repo.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(groups) != 1 || groups[0].Name != "Weak keys" {
+		t.Fatalf("List = %+v, want one group", groups)
+	}
+
+	saved.Name = "Updated"
+	updated, err := repo.Save(&saved)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if updated.Name != "Updated" {
+		t.Errorf("name = %q, want Updated", updated.Name)
+	}
+
+	if err := repo.Delete(saved.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	groups, _ = repo.List()
+	if len(groups) != 0 {
+		t.Errorf("expected empty list, got %d", len(groups))
+	}
+}
+
+func TestSessionRepository_AggregateKeyMistakes(t *testing.T) {
+	mgr, err := New(t.TempDir())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := mgr.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	sessions, err := NewSessionRepository(mgr)
+	if err != nil {
+		t.Fatalf("NewSessionRepository: %v", err)
+	}
+
+	payload := &domain.SessionPayload{
+		SessionTextMeta: &domain.SessionTextMeta{Text: "test"},
+		Mistakes:        map[string]int{"q": 2, "w": 1},
+	}
+	if _, err := sessions.Record(payload); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+	payload2 := &domain.SessionPayload{
+		SessionTextMeta: &domain.SessionTextMeta{Text: "test2"},
+		Mistakes:        map[string]int{"q": 3},
+	}
+	if _, err := sessions.Record(payload2); err != nil {
+		t.Fatalf("Record 2: %v", err)
+	}
+
+	agg, err := sessions.AggregateKeyMistakes(10)
+	if err != nil {
+		t.Fatalf("AggregateKeyMistakes: %v", err)
+	}
+	if agg["q"] != 5 {
+		t.Errorf("q mistakes = %d, want 5", agg["q"])
+	}
+	if agg["w"] != 1 {
+		t.Errorf("w mistakes = %d, want 1", agg["w"])
+	}
+}

--- a/internal/storage/sessions.go
+++ b/internal/storage/sessions.go
@@ -133,12 +133,8 @@ func cloneSession(src *domain.TypingSession) domain.TypingSession {
 			out.Mistakes[k] = v
 		}
 	}
-	if src.PracticeSessionMeta != nil {
-		meta := *src.PracticeSessionMeta
-		if len(meta.TargetKeys) > 0 {
-			meta.TargetKeys = append([]string(nil), meta.TargetKeys...)
-		}
-		out.PracticeSessionMeta = &meta
+	if len(src.TargetKeys) > 0 {
+		out.TargetKeys = append([]string(nil), src.TargetKeys...)
 	}
 	return out
 }

--- a/internal/storage/sessions.go
+++ b/internal/storage/sessions.go
@@ -133,5 +133,12 @@ func cloneSession(src *domain.TypingSession) domain.TypingSession {
 			out.Mistakes[k] = v
 		}
 	}
+	if src.PracticeSessionMeta != nil {
+		meta := *src.PracticeSessionMeta
+		if len(meta.TargetKeys) > 0 {
+			meta.TargetKeys = append([]string(nil), meta.TargetKeys...)
+		}
+		out.PracticeSessionMeta = &meta
+	}
 	return out
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -34,6 +34,7 @@ const (
 	textsIndexFile      = "texts/index.json"
 	fallbackContentFile = "texts/content/dfs-file-finder.txt"
 	sessionsFile        = "sessions.json"
+	practiceGroupsFile  = "practice-groups.json"
 )
 
 // Paths inside the embedded filesystem.
@@ -94,7 +95,15 @@ func (m *Manager) Init() error {
 	if err := m.ensureJSONFile(sessionsFile, nil); err != nil {
 		return err
 	}
+	if err := m.ensurePracticeGroupsFile(); err != nil {
+		return err
+	}
 	return nil
+}
+
+func (m *Manager) ensurePracticeGroupsFile() error {
+	defaultContent := []byte("{\n  \"version\": 1,\n  \"groups\": []\n}\n")
+	return m.ensureJSONFile(practiceGroupsFile, defaultContent)
 }
 
 // join constructs an absolute path by prepending the root directory.


### PR DESCRIPTION
 Summary

This PR adds two new practice modes to FingerGo.

 Targeted Practice

Users can generate exercises focused on specific key groups:

* Home Row
* Left Hand
* Right Hand
* Top Row
* Bottom Row
* Numbers
* Punctuation
* Symbols
* Weak Keys
* Custom Groups

Features:

* Group selection UI
* Exercise preview generation
* Session metadata support
* Weak key recommendations

 Custom Text Practice

Users can:

* Paste arbitrary text
* Preview before starting
* Practice immediately
* Optionally save later

Examples:

* Resume practice
* Interview answers
* Articles
* Notes
* Custom typing exercises

 Session Metadata

Added support for:

* PracticeMode
* PracticeGroupId
* PracticeGroupName
* TargetKeys

 Testing

Tested locally on:

* Linux Mint 22.3
* Go 1.26
* Wails 2.12

Verified:

* Group selection
* Exercise generation
* Start practice flow
* Custom text practice
* Session completion
* Session summaries

 Screenshots
<img width="1094" height="723" alt="image" src="https://github.com/user-attachments/assets/9db1cc4e-465f-4ef4-a31c-a43bce36bf02" />
<img width="969" height="655" alt="image" src="https://github.com/user-attachments/assets/896c7a9e-df2a-49a7-8d12-d531ccb24058" />



